### PR TITLE
Added option to install docopt, python module needed by watchmakers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cd /src/watchmakers \
   && mkdir -p /docker_interaction_software \
   && rsync -avz /src/watchmakers/tools/d* /docker_interaction_software/
 
-
+RUN pip install docopt
 
 # Copy dockerfile for record
 COPY Dockerfile Dockerfile


### PR DESCRIPTION
Testing if pip works in the docker file. Need to add docopt as a python option.