### PR TITLE
Addition of array version of the extruded polygon geo factory

### DIFF
--- a/src/geo/GeoBuilder.cc
+++ b/src/geo/GeoBuilder.cc
@@ -30,6 +30,7 @@
 #include <RAT/GeoPerfBoxFactory.hh>
 #include <RAT/GeoCutTubeFactory.hh>
 #include <RAT/GeoWatchmanShieldFactory.hh>
+#include <RAT/GeoPolyArrayFactory.hh>
 
 using namespace std;
 
@@ -62,6 +63,7 @@ GeoBuilder::GeoBuilder()
   new GeoPerfBoxFactory();
   new GeoCutTubeFactory();
   new GeoWatchmanShieldFactory();
+  new GeoPolyArrayFactory();
 
   // Register standard waveguides
   GlobalFactory<WaveguideFactory>::Register("cone",

--- a/src/geo/GeoPolyArrayFactory.cc
+++ b/src/geo/GeoPolyArrayFactory.cc
@@ -1,0 +1,77 @@
+#include <RAT/GeoPolyArrayFactory.hh>
+#include <RAT/Log.hh>
+#include <RAT/PolygonOrientation.hh>
+#include <RAT/TubeFacetSolid.hh>
+#include <G4SubtractionSolid.hh>
+#include <G4Tubs.hh>
+#include <G4TwoVector.hh>
+#include <vector>
+
+using namespace std;
+
+namespace RAT {
+    
+   G4VPhysicalVolume *GeoPolyArrayFactory::Construct(DBLinkPtr table)
+   {
+	
+      string volume_name = table->GetIndex();
+      G4double size_z = table->GetD("size_z") * CLHEP::mm;      // half thickness of plate
+      string poly_table_name = table->GetS("poly_table");
+      DBLinkPtr lpoly_table = DB::Get()->GetLink(poly_table_name);
+      const vector<G4double> &vertex_pnts_x = lpoly_table->GetDArray("x");
+      const vector<G4double> &vertex_pnts_y = lpoly_table->GetDArray("y"); 
+
+      // Optional parameters
+      G4double scale_fac = 1.0;      
+      try { scale_fac = table->GetD("scale_fac"); } 
+      catch (DBNotFoundError &e) { };
+  
+       G4double scale_fac_in = 0.0;      
+      try { scale_fac_in = table->GetD("scale_fac_in"); } 
+      catch (DBNotFoundError &e) { };
+  
+      // end optional parms
+
+      G4double poly_max = 0.0 * CLHEP::mm;
+      G4double poly_max_tmp = 0.0 * CLHEP::mm;
+      vector<G4TwoVector> g4Polygon;
+
+      for ( G4int i=0; i < G4int(vertex_pnts_x.size()); ++i ) 
+      {
+         g4Polygon.push_back( G4TwoVector(vertex_pnts_x[i] * CLHEP::mm, vertex_pnts_y[i] *CLHEP::mm ) );
+         poly_max_tmp = sqrt((vertex_pnts_x[i] * CLHEP::mm * vertex_pnts_x[i] * CLHEP::mm) + ( vertex_pnts_y[i] * CLHEP::mm *vertex_pnts_y[i] * CLHEP::mm));
+         if (poly_max_tmp >= poly_max)
+	         poly_max = poly_max_tmp;
+      }
+  
+      poly_max = poly_max * scale_fac;
+  
+      //Check the orientation of polygon to be defined clockwise
+      CheckOrientation(g4Polygon);
+  
+      G4VSolid* base_solid = MakeTubeFacetSolid(volume_name,
+					    g4Polygon,
+					    scale_fac,
+					    size_z,
+					    0.0,
+					    poly_max);
+  
+      if ((scale_fac_in > 0) && (scale_fac_in < scale_fac))
+      {
+         G4VSolid* sub_solid = MakeTubeFacetSolid("sub_solid",
+						g4Polygon,
+						scale_fac_in,
+						size_z*1.1,
+						0.0,
+						poly_max/scale_fac*scale_fac_in);
+      
+         base_solid = new G4SubtractionSolid(volume_name, base_solid, sub_solid, 0, G4ThreeVector(0.0,0.0,0.0));
+      }
+
+	   return GeoSolidArrayFactoryBase::Construct(base_solid, table);     
+   }
+    
+} // namespace RAT
+
+
+

--- a/src/geo/GeoPolyArrayFactory.hh
+++ b/src/geo/GeoPolyArrayFactory.hh
@@ -1,0 +1,16 @@
+#ifndef __RAT_GeoPolyArrayFactory__
+#define __RAT_GeoPolyArrayFactory__
+
+#include <RAT/GeoSolidArrayFactoryBase.hh>
+
+namespace RAT {
+ class GeoPolyArrayFactory : public GeoSolidArrayFactoryBase {
+ public:
+   GeoPolyArrayFactory() : GeoSolidArrayFactoryBase("polygonarray") {};
+   using GeoSolidArrayFactoryBase::Construct;
+   virtual G4VPhysicalVolume *Construct(DBLinkPtr table);
+ };
+  
+} // namespace RAT
+
+#endif


### PR DESCRIPTION
Addition of extruded polygon array factory, usage is analogous to (most) geometry objects. Type name is `polyarray`. Additional mandatory fields are:

`size_z`: _float_ describing the thickness (extrusion) of the polygon shape
`poly_table`: _string_ specifying the name of the table containing vertices 
`pos_table`: _string_ specifying the name of the table containing positions, analogous to PMTArray
`orientation`: _string_ with `point` or `manual` option, analogous to PMTArray

The poly_table will need to contain the following fields describing the polygon vertices in clockwise order:
`x`: _float[n]_ containing the x-component of the nth polygon vertex
`y`: _float[n]_ containing the y-component of the nth polygon vertex

The `pos_table` is the same as for `PMTArray` or `TubeArray`.

An example geometry demonstrating the usage is attached (rename to .geo)
[PolyArrayExample.txt](https://github.com/AIT-WATCHMAN/rat-pac/files/3383087/PolyArrayExample.txt) or can be found at [here](https://gist.github.com/yschnellbach/32a97b400ecf0b7a89df96a211148476). It should be loaded into a macro using `/rat/db/load` after the detector has been setup.

The current implementation inherits some restrictions from the existing implementation of polygons and arrays:
- Only convex shapes are possible (same as non-array polygon factory)
- Correct orientation can be awkward (current array implementation assumes objects with rotational symmetry around z-axis: PMTs and Tubes)

