### PR TITLE
Updates to mu metal reflectivity

### DIFF
--- a/data/Watchman/Watchman.geo
+++ b/data/Watchman/Watchman.geo
@@ -213,6 +213,8 @@ end_idx: 4329, //idx of the last pmt
 start_idx: 0, //idx of the first pmt
 pmt_model: "r7081pe",
 mu_metal: 0,
+mu_metal_material: "aluminum",
+mu_metal_surface: "aluminum",
 pmt_detector_type: "idpmt",
 sensitive_detector: "/mydet/pmt/inner",
 efficiency_correction: 0.90000,

--- a/mac/watchman.mac
+++ b/mac/watchman.mac
@@ -3,6 +3,10 @@
 /glg4debug/glg4param omit_hadronic_processes  0.0
 
 /rat/db/set DETECTOR experiment "Watchman"
+# Turn on mu metal, change surface and material
+/rat/db/set GEO[inner_pmts] mu_metal 1
+#/rat/db/set GEO[inner_pmts] mu_metal_material "aluminum"
+#/rat/db/set GEO[inner_pmts] mu_metal_surface "mirror"
 /rat/db/set DETECTOR detector_factory "Watchman"
 /rat/db/set WATCHMAN_PARAMS photocathode_coverage 0.25
 
@@ -11,7 +15,7 @@
 #/rat/db/set GEO[fiducial] material "Gd_wbls_10pct"
 
 /run/initialize
-#/tracking/storeTrajectory 1
+/tracking/storeTrajectory 1
 
 # BEGIN EVENT LOOP
 /rat/proc lesssimpledaq
@@ -22,8 +26,8 @@
 /rat/proclast outroot
 #END EVENT LOOP
 
-/generator/add combo gun2:fill
-/generator/vtx/set e-  0 0 0 0 5.0 5.0
-/generator/pos/set 0 0 0
+/generator/add combo pbomb:point
+/generator/vtx/set 1000 400
+/generator/pos/set 0 0 4000
 
-/run/beamOn 10
+/run/beamOn 1

--- a/mac/watchman_visualize.mac
+++ b/mac/watchman_visualize.mac
@@ -2,11 +2,12 @@
 /glg4debug/glg4param omit_hadronic_processes 1.0
 
 /rat/db/set DETECTOR experiment "Watchman"
+/rat/db/set GEO[inner_pmts] mu_metal 1
 /rat/db/set DETECTOR detector_factory "Watchman"
 /rat/db/set WATCHMAN_PARAMS photocathode_coverage 0.25
 
 # Visualize the calibration source
-/rat/db/load Watchman/DecayChamber.geo
+#/rat/db/load Watchman/DecayChamber.geo
 #/rat/db/set GEO[sourcecan] posz 10000.0
 
 /run/initialize

--- a/src/geo/GeoPMTFactoryBase.cc
+++ b/src/geo/GeoPMTFactoryBase.cc
@@ -23,6 +23,7 @@
 #include "G4VFastSimulationModel.hh"
 #include "GLG4PMTOpticalModel.hh"
 #include "G4PhysicsOrderedFreeVector.hh"
+#include "G4LogicalSkinSurface.hh"
 
 #include "G4RandomDirection.hh"
 
@@ -83,9 +84,32 @@ namespace RAT {
         DBLinkPtr lpmt = DB::Get()->GetLink("PMT", pmt_model);
 
         //add mu metal shields
-        int    mu_metal       = table->GetI("mu_metal");
-        bool   mumetalshields = false;
-        if( mu_metal == 1 ){ mumetalshields = true; G4cout << "Mu metal shield is added!! \n "; }
+        int mu_metal = 0; // default to no shields
+        try { mu_metal = table->GetI("mu_metal"); }
+        catch (DBNotFoundError &e) { }
+        // Material Properties
+        G4Material* mu_metal_material = G4Material::GetMaterial("aluminum");
+        try { mu_metal_material = G4Material::GetMaterial( table->GetS("mu_metal_material") ); }
+        catch (DBNotFoundError &e) { }
+        // Surface Properties
+        G4SurfaceProperty* mu_metal_surface = Materials::optical_surface["aluminum"];
+        try { mu_metal_surface = Materials::optical_surface[ table->GetS("mu_metal_surface") ]; }
+        catch (DBNotFoundError &e) { }
+        G4cout << "Mu metal shield is added!! \n "; 
+
+        G4Tubs* mumetal_solid = new G4Tubs("mumetal_solid",
+                                           13.0*CLHEP::cm, // rmin
+                                           13.2*CLHEP::cm, // rmax
+                                           10.0*CLHEP::cm, // z
+                                           0., CLHEP::twopi );
+        G4LogicalVolume *mumetal_log=new G4LogicalVolume(
+            mumetal_solid,                     // G4VSolid
+            mu_metal_material,                 // G4Material
+            "mumetal_log");
+        G4LogicalSkinSurface* mumetal_skin = new G4LogicalSkinSurface(
+            "mumetal_surface",
+            mumetal_log,       //Logical Volume
+            mu_metal_surface); //Surface Property
 
         PMTConstructionParams pmtParam;
         pmtParam.faceGap = 0.1 * CLHEP::mm;
@@ -210,15 +234,6 @@ namespace RAT {
         G4LogicalVolume *logiPMT = pmtConstruct.NewPMT(volume_name, vis_simple);
         G4LogicalVolume *logiWg = 0;
         G4ThreeVector offsetWg;
-
-        //add mumetal shield if needed
-        //bool mumetalshields= true;
-        G4Tubs* mumetal_solid = new G4Tubs("mumetal_solid",
-                                           13.0*CLHEP::cm,13.2*CLHEP::cm,
-                                           10.0*CLHEP::cm,
-                                           0., CLHEP::twopi );
-        G4LogicalVolume *mumetal_log=new G4LogicalVolume(mumetal_solid, pmtParam.dynode, "mumetal_log");
-
 
 
         //G4VPhysicalVolume *mid_water_phys = FindPhysMother("mid_water");
@@ -545,7 +560,7 @@ namespace RAT {
             G4ThreeVector offsetmumetal = G4ThreeVector(0.0, 0.0, /*-10.0*/0.0*CLHEP::cm);
             //G4cout << "pmtpos is " << pmtpos << "\n";
             G4ThreeVector mumetalpos = pmtpos + offsetmumetal;
-            if (mumetalshields) {
+            if (mu_metal) {
                 new G4PVPlacement
                 ( 0,
                  mumetalpos,


### PR DESCRIPTION
G4LogicalSkinSurface added to allow the mu_metal to have surface
properties. The optics are defined in Materials.cc pulling from
OPTICS.ratdb and MATERIALS.ratdb. The surface and bulk material
can be defined within the macro itself at run-time.

To use, checkout watchman.mac. The materials and surfaces can be changed directly there.