### PR TITLE
Fixing unclosed brackets in several CMakeLists.txt

### DIFF
--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(cmd OBJECT
 # Set our include directories
 target_include_directories(cmd PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(core OBJECT
 # Set our include directories
 target_include_directories(core PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/daq/CMakeLists.txt
+++ b/src/daq/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(daq OBJECT
 # Set our include directories
 target_include_directories(daq PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/db/CMakeLists.txt
+++ b/src/db/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(db OBJECT
 # Set our include directories
 target_include_directories(db PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/fit/CMakeLists.txt
+++ b/src/fit/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(fit OBJECT
 # Set our include directories
 target_include_directories(fit PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 ### Bonsai
 add_library(_bonsai OBJECT
@@ -41,7 +41,7 @@ add_library(_bonsai OBJECT
 # Set our include directories
 target_include_directories(_bonsai PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/gen/CMakeLists.txt
+++ b/src/gen/CMakeLists.txt
@@ -44,7 +44,7 @@ add_library(gen OBJECT
 # Set our include directories
 target_include_directories(gen PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/geo/CMakeLists.txt
+++ b/src/geo/CMakeLists.txt
@@ -55,7 +55,7 @@ add_library(geo OBJECT
 # Set our include directories
 target_include_directories(geo PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(io OBJECT
 # Set our include directories
 target_include_directories(io PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/physics/CMakeLists.txt
+++ b/src/physics/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(physics OBJECT
 # Set our include directories
 target_include_directories(physics PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/stlplus/CMakeLists.txt
+++ b/src/stlplus/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(stlplus OBJECT
 # Set our include directories
 target_include_directories(stlplus PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(util OBJECT
 # Set our include directories
 target_include_directories(util PUBLIC
         $<BUILD_INTERFACE:${RATPAC_INCDIR}>
-        $<INSTALL_INTERFACE:include)
+        $<INSTALL_INTERFACE:include>)
 
 # Copy our headers when installing
 file(COPY include/ DESTINATION ${RATPAC_INCDIR})


### PR DESCRIPTION
Discovered several unclosed brackets in some CMakeLists.txt, which looks very much like a copy & paste error.

Fixing this enhances compatibility with alternative build systems which can be more strict about the syntax emitted by CMake.