### PR TITLE
Fix to load rat in python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11...3.14)
-project(ratpac VERSION 1.0.0
+project(ratpac VERSION 1.0.1
                 DESCRIPTION "Watchman RAT-PAC"
                 LANGUAGES C CXX Fortran)
 

--- a/python/rat/__init__.py
+++ b/python/rat/__init__.py
@@ -8,7 +8,10 @@ sys.argv = sys.argv[:1]
 
 # Load this shared library before ROOT
 import ctypes
-ctypes.cdll.LoadLibrary(os.path.join(RATROOT, 'lib', 'libSilenceRooFitBanner.so'))
+try:
+    ctypes.cdll.LoadLibrary(os.path.join(RATROOT, 'lib', 'libSilenceRooFitBanner.so'))
+except OSError:
+    ctypes.cdll.LoadLibrary(os.path.join(RATROOT, 'lib', 'libSilenceRooFitBanner.dylib'))
 
 import ROOT
 from ROOT import gROOT, TH1F

--- a/python/rat/__init__.py
+++ b/python/rat/__init__.py
@@ -14,7 +14,7 @@ import ROOT
 from ROOT import gROOT, TH1F
 # Detect if we already loaded the dictionary, for example inside RAT already
 if ROOT.TClassTable.GetID("RAT::DS::Root") == -1:
-    gROOT.ProcessLine(".x "+os.path.join(RATROOT, "rootinit.C"))
+    gROOT.ProcessLine(".x "+os.path.join(RATROOT, "src/rootinit.C"))
 from ROOT import RAT
 
 # Unhide command line options from $!$#! ROOT

--- a/python/rattest/__init__.py
+++ b/python/rattest/__init__.py
@@ -12,7 +12,7 @@ from ROOT import gROOT, gSystem, TFile, TH1, TCanvas, kRed, kBlue, kDashed
 sys.argv = _argv
 
 gROOT.SetBatch(True)
-gROOT.ProcessLine(".x "+os.path.join(os.environ['RATROOT'], 'rootinit.C'))
+gROOT.ProcessLine(".x "+os.path.join(os.environ['RATROOT'], 'src/rootinit.C'))
 TH1.SetDefaultSumw2()
 
 ### Other modules ###

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -24,7 +24,14 @@ file(COPY include/ DESTINATION ${RATPAC_INCDIR})
 
 #### Target: Shared library to make RooFit stop printing that stupid banner
 add_library(SilenceRooFitBanner SHARED src/SilenceRooFitBanner.cc)
+
 target_link_libraries(SilenceRooFitBanner PUBLIC ${ROOT_LIBRARIES})
+
+set_target_properties( SilenceRooFitBanner
+  PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+    LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+
 install(TARGETS SilenceRooFitBanner
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib)


### PR DESCRIPTION
Fix to resolve issue #65 . The file `libSilenceRooFitBanner.so` now lives in build/lib along with `libRATEvent.so`. Also `python/rat/__init__.py` looks for `rootinit.C` in `build/src` instead of `build`