### PR TITLE
Hotfix lassen batchmode

### DIFF
--- a/tools/rat/rat.cc
+++ b/tools/rat/rat.cc
@@ -139,14 +139,17 @@ int main(int argc, char **argv) {
 
     // interactive or batch according to command-line args
     bool isInteractive = false;
-    G4UIExecutive *theSession;
+    G4UIExecutive *theSession = NULL;
+    std::vector<std::string> arguments(argv+1, argv+argc);
+    if( std::find(arguments.begin(), arguments.end(), "-") != arguments.end() ||
+        RAT::optind - argc == 0 )
+    {
+      isInteractive = true;
+      theSession = new G4UIExecutive(argc, argv);
+    }
 
     if (RAT::optind - argc == 0) 
     {
-      // Interactive mode
-      isInteractive = true;
-      theSession = new G4UIExecutive(argc, argv);
-
       // G4UIterminal is a (dumb) terminal.
       // ..but it can be made smart by adding a "shell" to it
       theUI->ApplyCommand("/control/execute prerun.mac");
@@ -160,13 +163,7 @@ int main(int argc, char **argv) {
       {
         // process list of macro files; "-" means interactive user session
         G4String fileName = argv[iarg];
-        if (fileName == "-") 
-        {
-          // interactive session requested
-          isInteractive = true;
-          theSession = new G4UIExecutive(argc, argv);
-        } 
-        else 
+        if (fileName != "-")
         {
           if (options.save_macro) 
           {

--- a/tools/rat/rat.cc
+++ b/tools/rat/rat.cc
@@ -139,12 +139,13 @@ int main(int argc, char **argv) {
 
     // interactive or batch according to command-line args
     bool isInteractive = false;
-    G4UIExecutive *theSession = new G4UIExecutive(argc, argv);
+    G4UIExecutive *theSession;
 
     if (RAT::optind - argc == 0) 
     {
       // Interactive mode
       isInteractive = true;
+      theSession = new G4UIExecutive(argc, argv);
 
       // G4UIterminal is a (dumb) terminal.
       // ..but it can be made smart by adding a "shell" to it
@@ -163,6 +164,7 @@ int main(int argc, char **argv) {
         {
           // interactive session requested
           isInteractive = true;
+          theSession = new G4UIExecutive(argc, argv);
         } 
         else 
         {


### PR DESCRIPTION
In rat.cc, changes were made to declare the interactive session before looping through macros, and then display afterwards. On systems where there is no X-display though, rat will seg-fault prior to the macros even without need to display the graphics. This fix predeclares the system as NULL and then only initializing when graphics is need. Rat should now work on all systems in any of these forms:
```bash
rat
rat watchman.mac
rat watchman_visualize.mac -
```
The "-" is searched for prior to the macro event loop so that its order on the command line doesn't matter.
```
rat watchman_visualize.mac -
rat - watchman_visualize.mac
```
are equivalent.