### PR TITLE
Rayleigh Scattering

### DIFF
--- a/src/physics/CMakeLists.txt
+++ b/src/physics/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(physics OBJECT
         src/GLG4OpAttenuation.cc
         src/GLG4PMTOpticalModel.cc
         src/GLG4Scint.cc
+        src/OpRayleigh.cc
         src/PhotonThinning.cc
         src/PhysicsList.cc)
 

--- a/src/physics/include/RAT/OpRayleigh.hh
+++ b/src/physics/include/RAT/OpRayleigh.hh
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020 by the Snoplus collaboration
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms are permitted
+ * provided that the above copyright notice and this paragraph are
+ * duplicated in all such forms and that any documentation,
+ * advertising materials, and other materials related to such 
+ * distribution and use acknowledge that the software was developed
+ * by the Snoplus collaboration. The name of the
+ * Snoplus collaboration may not be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+///////////////////////////////////////////////////////////////////////////////
+//
+// Simulates optical Rayleigh scattering. This class simulates
+// Rayleigh scattering. It should be used in preference to the Geant4
+// G4OpRayleigh class as it will calculate mean free paths for all
+// materials not just water.
+//
+// Author: P G Jones <p.g.jones@qmul.ac.uk>
+//
+// REVISION HISTORY:
+//     2014-01-08 : P G Jones - New file.
+//     12-05-2015 : I Coulter - Remove use of the "SNOMAN style" RS_SCALE_FACTOR
+//                              This already exists in SNOMANOpRayleigh, isn't
+//                              used in general use and causes confusion.
+//
+//////////////////////////////////////////////////////////////////////////////
+#ifndef __RAT_OpRayleigh_hh__
+#define __RAT_OpRayleigh_hh__
+
+#include <G4VDiscreteProcess.hh>
+#include <G4OpticalPhoton.hh>
+
+class G4PhysicsTable;
+class G4MaterialPropertiesTable;
+
+namespace RAT
+{
+
+class OpRayleigh : public G4VDiscreteProcess
+{
+public:
+  // Construct the class
+  //
+  // processName: optional, defaults to OpRayleigh
+  // type: optional, defaults to fOptical
+  OpRayleigh( const G4String& processName = "OpRayleigh",
+              G4ProcessType type = fOptical );
+
+  // Deletes the physics table
+  ~OpRayleigh();
+
+  // Returns true if this code is applicable to the particle type
+  //
+  // particleType: definition of the particle type
+  // returns true if the particle type is an optical photon
+  G4bool IsApplicable( const G4ParticleDefinition& particleType ) { return ( &particleType == G4OpticalPhoton::OpticalPhoton() ); }
+
+  // Returns the mean free path for the track in mm.
+  //
+  // previousStepSize and condition are unused
+  G4double GetMeanFreePath( const G4Track& track,
+                            G4double previousStepSize,
+                            G4ForceCondition* condition );
+
+  // Invoke scattering to the track
+  //
+  // returns a particle change description
+  G4VParticleChange* PostStepDoIt( const G4Track& track,
+                                   const G4Step& step );
+private:
+  // Builds the physics table, i.e. a table of mean free paths
+  void BuildThePhysicsTable();
+
+  G4PhysicsTable* fPhysicsTable; // The physics table used
+};
+
+} //::RAT
+
+#endif

--- a/src/physics/src/OpRayleigh.cc
+++ b/src/physics/src/OpRayleigh.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2020 by the Snoplus collaboration
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms are permitted
+ * provided that the above copyright notice and this paragraph are
+ * duplicated in all such forms and that any documentation,
+ * advertising materials, and other materials related to such 
+ * distribution and use acknowledge that the software was developed
+ * by the Snoplus collaboration. The name of the
+ * Snoplus collaboration may not be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <Randomize.hh>
+#include <G4OpProcessSubType.hh>
+
+#include <RAT/OpRayleigh.hh>
+#include <RAT/TrackInfo.hh>
+
+using CLHEP::twopi;
+
+using namespace RAT;
+
+OpRayleigh::OpRayleigh( const G4String& processName,
+                          G4ProcessType type)
+  : G4VDiscreteProcess( processName, type )
+{
+  SetProcessSubType( fOpRayleigh );
+
+  fPhysicsTable = NULL;
+  BuildThePhysicsTable();
+}
+
+OpRayleigh::~OpRayleigh()
+{
+  if( fPhysicsTable != NULL )
+    {
+      fPhysicsTable->clearAndDestroy();
+      delete fPhysicsTable;
+    }
+}
+
+G4VParticleChange*
+OpRayleigh::PostStepDoIt( const G4Track& track,
+                          const G4Step& step )
+{
+  aParticleChange.Initialize( track );
+  const G4DynamicParticle* aParticle = track.GetDynamicParticle();
+
+  double psi = 0.0;
+  do
+    {
+       psi = twopi * G4UniformRand() / 2.0;
+    }
+  while( G4UniformRand() > pow( sin( psi ) , 3 ) );
+  const double phi = G4UniformRand() * twopi;
+
+  const G4ThreeVector oldMomentum = aParticle->GetMomentumDirection().unit();
+  const G4ThreeVector oldPolarisation = aParticle->GetPolarization().unit();
+  const G4ThreeVector e2 = oldMomentum.cross( oldPolarisation );
+
+  // oldPolarisation is Z, oldMomentum is x and e2 y
+  G4ThreeVector newMomentum = cos( psi ) * oldPolarisation + sin( psi ) * cos( phi ) * oldMomentum + sin( psi ) * sin( phi ) * e2;
+  newMomentum.unit();
+
+  G4ThreeVector newPolarisation = oldPolarisation - cos( psi ) * newMomentum;
+  newPolarisation.unit();
+
+  aParticleChange.ProposePolarization( newPolarisation );
+  aParticleChange.ProposeMomentumDirection( newMomentum );
+
+
+  RAT::TrackInfo* trackHistory = dynamic_cast<RAT::TrackInfo*>(track.GetUserInformation());
+  if (trackHistory) {
+    //trackHistory->AddToHistory(RAT::DS::MCPE::hRayleighScatt); //FIXME rat-pac does not have
+  }
+
+  return G4VDiscreteProcess::PostStepDoIt( track, step );
+}
+
+G4double
+OpRayleigh::GetMeanFreePath( const G4Track& track,
+                             G4double,
+                             G4ForceCondition* )
+{
+  const G4DynamicParticle* particle = track.GetDynamicParticle();
+  const G4double photonMomentum = particle->GetTotalMomentum();
+  const G4Material* material = track.GetMaterial();
+  G4PhysicsOrderedFreeVector* rayleigh = static_cast<G4PhysicsOrderedFreeVector*>( (*fPhysicsTable)( material->GetIndex() ) );
+
+  G4double rsLength = DBL_MAX;
+  if( rayleigh != NULL )
+    rsLength = rayleigh->Value( photonMomentum );
+  return rsLength;
+}
+
+void
+OpRayleigh::BuildThePhysicsTable()
+{
+  if( fPhysicsTable )
+    return;
+  const G4MaterialTable* theMaterialTable = G4Material::GetMaterialTable();
+  const G4int numOfMaterials = G4Material::GetNumberOfMaterials();
+  fPhysicsTable = new G4PhysicsTable( numOfMaterials );
+
+  for( G4int iMaterial = 0; iMaterial < numOfMaterials; iMaterial++ )
+    {
+      G4Material* material = (*theMaterialTable)[iMaterial];
+      G4MaterialPropertiesTable* materialProperties = material->GetMaterialPropertiesTable();
+      G4PhysicsOrderedFreeVector* rayleigh = NULL;
+      if( materialProperties != NULL )
+        {
+          rayleigh = materialProperties->GetProperty( "RSLENGTH" );
+        }
+      fPhysicsTable->insertAt( iMaterial, rayleigh );
+    }
+}

--- a/src/physics/src/PhysicsList.cc
+++ b/src/physics/src/PhysicsList.cc
@@ -10,6 +10,7 @@
 #include <G4Cerenkov.hh>
 #include <G4OpBoundaryProcess.hh>
 #include <G4RunManager.hh>
+#include <RAT/OpRayleigh.hh>
 #include <RAT/GLG4OpAttenuation.hh>
 #include <RAT/GLG4Scint.hh>
 #include <RAT/GLG4SteppingAction.hh>
@@ -84,6 +85,8 @@ void PhysicsList::ConstructOpticalProcesses() {
 
   // Optical boundary processes: default G4
   G4OpBoundaryProcess* opBoundaryProcess = new G4OpBoundaryProcess();
+  // Rayleigh Scattering
+  OpRayleigh* opRayleigh = new OpRayleigh();
 
   // Wavelength shifting: User-selectable via PhysicsListMessenger
   if (this->wlsModel) {
@@ -120,6 +123,7 @@ void PhysicsList::ConstructOpticalProcesses() {
     if (particleName == "opticalphoton") {
       pmanager->AddDiscreteProcess(attenuationProcess);
       pmanager->AddDiscreteProcess(opBoundaryProcess);
+      pmanager->AddDiscreteProcess(opRayleigh);
     }
   }
 }


### PR DESCRIPTION
Taken from SNO+, this activates rayleigh scattering through the
RSLENGTH ratdb entry. Acknowledgement of SNO+ required for use.
Currently using BSD license until told otherwise.
Scattering added as a new physics step in PhysicsList.cc.