### PR TITLE
fixing mass of particle when dat file is used

### DIFF
--- a/src/gen/src/GLG4VertexGen.cc
+++ b/src/gen/src/GLG4VertexGen.cc
@@ -918,9 +918,13 @@ GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVector &dx, G4double dt)
 				 PHEP3*energy_unit );
     }
     if (PHEP5 != req_novalue)
-      particle->SetMass( PHEP5*energy_unit );
+      particle->SetMass( PHEP5*energy_unit ); //this is not working and I don't know why (F.Sutanto, Apr 2020)
     if (polx != 0.0 || poly != 0.0 || polz != 0.0)
       particle->SetPolarization(polx, poly, polz);
+      
+      //I will just set the mass here (F. Sutanto, Apr 2020)
+      G4ParticleDefinition * myPar = G4ParticleTable::GetParticleTable()->FindParticle(  IDHEP );
+      particle->SetMass( myPar->GetPDGMass() );
 
     // create G4HEPEvtParticle object
     G4HEPEvtParticle* hepParticle

--- a/src/gen/src/GLG4VertexGen.cc
+++ b/src/gen/src/GLG4VertexGen.cc
@@ -922,9 +922,9 @@ GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVector &dx, G4double dt)
     if (polx != 0.0 || poly != 0.0 || polz != 0.0)
       particle->SetPolarization(polx, poly, polz);
       
-      //I will just set the mass here (F. Sutanto, Apr 2020)
-      G4ParticleDefinition * myPar = G4ParticleTable::GetParticleTable()->FindParticle(  IDHEP );
-      particle->SetMass( myPar->GetPDGMass() );
+    //I will just set the mass here (F. Sutanto, Apr 2020)
+    G4ParticleDefinition * myPar = G4ParticleTable::GetParticleTable()->FindParticle(  IDHEP );
+    particle->SetMass( myPar->GetPDGMass() );
 
     // create G4HEPEvtParticle object
     G4HEPEvtParticle* hepParticle


### PR DESCRIPTION
Mass of particle is not registered correctly when a dat file is used to generate events. 

Tomi and I observed an unexpected n9 response when we generated neutrons in Watchman volume using a dat file. See this n9 response below:
<img width="694" alt="Screen Shot 2020-04-17 at 12 38 40 AM" src="https://user-images.githubusercontent.com/19483957/79544520-fe8c6780-8043-11ea-8068-006278273d88.png">

The fast neutrons (they are thermal neutrons actually) were generated using a dat file. 
Li9 delay, He8 delay, and N17 delay (also thermal neutrons) were generated using a generator.
As it shown above, they unexpectedly have different shape...

Apparently unlike neutrons that are generated using a generator, neutrons that are generated using a dat file won't thermalize down to 10^-8ish MeV. Hence, they are likely to be captured by hydrogen (~75%) rather than gadolinium. This is why their n9 shapes are different and they are captured at longer time.

The reason why these neutrons' energy won't go down to 10^-8ish MeV is because their mass is not registered correctly when a dat file is used to generate them. Since their mass is not correct, they cannot pass their energies correctly to protons.

I am not quite sure why this line won't work in GLG4VertexGen.cc:
       particle->SetMass( PHEP5*energy_unit );
but it seems that this line worked until early 2017ish.
I have added extra lines to redefine the mass:
    G4ParticleDefinition * myPar = G4ParticleTable::GetParticleTable()->FindParticle(  IDHEP );
    particle->SetMass( myPar->GetPDGMass() );


