### PR TITLE
fix pmt time

### DIFF
--- a/src/daq/src/LessSimpleDAQProc.cc
+++ b/src/daq/src/LessSimpleDAQProc.cc
@@ -130,7 +130,8 @@ namespace RAT {
                 
                 time = pmtARRAY[pmtIndex][0];
                 
-                if (fabs(time-clusterTime[kk]) <400) {
+                //if (fabs(time-clusterTime[kk]) <400) {
+                if ( time-clusterTime[kk]<timeWindow && time-clusterTime[kk]>=0.0 ){
                     
                     /*if (pmtARRAY[pmtIndex][2] != oldID){
                      timeTmp = time;


### PR DESCRIPTION
This change might solve problem #97.
Thanks to input from Liz, Tomi, Marc, and Morgan!

////////////////////////////////////////////////////////////////////////
There are two problems in #97:
1- I simulate thermal neutrons in the detector. I expect to see only one subevent for each event, but sometimes I see two subevents.
2- When there are more than one subevent, PMTs in subevent 1,2,3,... often show negative hit time (PMTs in subevent 0 are fine).

////////////////////////////////////////////////////////////////////////
Problem no.1:
Apparently this is not a problem. As those people above pointed out, it's merely due to tyvek implementation. The photons are bouncing in the veto region, spreading the pmt hit time. This is why we see multiple subevents when neutron is captured in veto volume. 

This is how subevent ditribution looks like when capture happens in inner detector:
<img width="281" alt="Screen Shot 2020-06-02 at 8 38 12 PM" src="https://user-images.githubusercontent.com/19483957/83593283-3dea1700-a511-11ea-883a-6f9aa84a5313.png">

This is how subevent distribution looks like when capture happens in veto volume:
<img width="269" alt="Screen Shot 2020-06-02 at 8 39 30 PM" src="https://user-images.githubusercontent.com/19483957/83593276-388ccc80-a511-11ea-8d2e-38422c881d47.png">

////////////////////////////////////////////////////////////////////////
Problem no.2:
This is a real problem. Liz pointed out that line 133 is problematic.
The time bracket (400ns) we use to group pmt hits as a subevent in line 133 does not match the time bracket (800ns = timeWindow) we use to choose the cluster time (time of the subevent group).

However, even if you change the "400ns" in line 133 to "timeWindow", you're still going to get many negative pmt times and this is because we shouldn't use absolute value in line 133.
I output some pmt info from lesssimpledaq to show how pmt hits in one event (capture in veto) look like and how they look like after they are grouped into subevents:
-------------------------------------sorted pmts hits---------------
(time,charge,id):(5.612e+04,1.016e+00,3573.000000) 
(time,charge,id):(5.612e+04,7.202e-01,3573.000000) 
(time,charge,id):(5.613e+04,1.389e+00,3571.000000) 
(time,charge,id):(5.613e+04,5.896e-01,3613.000000) 
(time,charge,id):(5.616e+04,7.399e-01,3631.000000) 
(time,charge,id):(5.616e+04,1.025e+00,3641.000000) 
(time,charge,id):(5.621e+04,1.161e+00,3575.000000) 
(time,charge,id):(5.622e+04,7.242e-01,3515.000000) 
(time,charge,id):(5.623e+04,1.437e+00,3565.000000) 
(time,charge,id):(5.624e+04,7.684e-01,3571.000000) 
(time,charge,id):(5.624e+04,1.273e+00,3557.000000) 
(time,charge,id):(5.626e+04,9.445e-01,3479.000000) 
(time,charge,id):(5.628e+04,8.952e-01,3653.000000) 
(time,charge,id):(5.630e+04,1.201e+00,3446.000000) 
(time,charge,id):(5.631e+04,1.144e+00,3499.000000) 
(time,charge,id):(5.636e+04,1.826e+00,3621.000000) 
(time,charge,id):(5.639e+04,1.255e+00,3655.000000) 
(time,charge,id):(5.644e+04,1.050e+00,3334.000000) 
(time,charge,id):(5.646e+04,1.745e+00,3438.000000) 
(time,charge,id):(5.646e+04,1.106e+00,3384.000000) 
(time,charge,id):(5.646e+04,6.726e-01,3337.000000) 
(time,charge,id):(5.652e+04,1.540e+00,3520.000000) 
(time,charge,id):(5.685e+04,1.171e+00,3349.000000) 
(time,charge,id):(5.694e+04,1.368e+00,3542.000000) 
(time,charge,id):(5.749e+04,1.006e+00,3326.000000) 
(time,charge,id):(5.766e+04,5.602e-01,3643.000000) 
-------------------------------------subevents grouping------------------
subevent 0      cluster time 56120.609443 
(time,charge,id):(0.000e+00,1.736e+00,3573.000000) 
(time,charge,id):(5.805e+00,2.158e+00,3571.000000) 
(time,charge,id):(1.381e+01,5.896e-01,3613.000000) 
(time,charge,id):(3.689e+01,7.399e-01,3631.000000) 
(time,charge,id):(4.221e+01,1.025e+00,3641.000000) 
(time,charge,id):(8.875e+01,1.161e+00,3575.000000) 
(time,charge,id):(9.595e+01,7.242e-01,3515.000000) 
(time,charge,id):(1.121e+02,1.437e+00,3565.000000) 
(time,charge,id):(1.234e+02,1.273e+00,3557.000000) 
(time,charge,id):(1.375e+02,9.445e-01,3479.000000) 
(time,charge,id):(1.560e+02,8.952e-01,3653.000000) 
(time,charge,id):(1.842e+02,1.201e+00,3446.000000) 
(time,charge,id):(1.846e+02,1.144e+00,3499.000000) 
(time,charge,id):(2.374e+02,1.826e+00,3621.000000) 
(time,charge,id):(2.667e+02,1.255e+00,3655.000000) 
(time,charge,id):(3.180e+02,1.050e+00,3334.000000) 
(time,charge,id):(3.375e+02,1.745e+00,3438.000000) 
(time,charge,id):(3.425e+02,1.106e+00,3384.000000) 
(time,charge,id):(3.442e+02,6.726e-01,3337.000000) 
(time,charge,id):(3.976e+02,1.540e+00,3520.000000) 
(time,charge,id):(7.268e+02,1.171e+00,3349.000000) 
subevent 1      cluster time 56936.035322 
(time,charge,id):(0.000e+00,1.368e+00,3542.000000) 
(time,charge,id):(5.522e+02,1.006e+00,3326.000000) 
(time,charge,id):(7.258e+02,5.602e-01,3643.000000) 

The above example has line 133 corrected already. But notice that if you use an absolute value in line 133, all pmt hits in subevent 0 will be part of subvevent 1 except for the first four pmts. These extra pmts will appear in subevent 1 with negative time.

