### PR TITLE
Hotfix for IBDGen

### DIFF
--- a/src/gen/src/IBDgen.cc
+++ b/src/gen/src/IBDgen.cc
@@ -14,6 +14,8 @@ const double GFERMI = 1.16639e-11 / MeV / MeV;
  
 IBDgen::IBDgen()
 {
+  SetPositronState( true );
+  SetNeutronState( true );
   messenger = new IBDgenMessenger(this);
   SpectrumIndex = "default";
   UpdateFromDatabaseIndex();


### PR DESCRIPTION
The neutron / positron status was unset by default. This would cause
c++ to assign it a random value, and the messenger only rectifies
this if called. The status is now set in the default IBDgen constructor,
then modified by the messenger.

Fixes #108 