### PR TITLE
Store photon creation process in MCPhoton

### DIFF
--- a/src/core/include/RAT/Gsim.hh
+++ b/src/core/include/RAT/Gsim.hh
@@ -72,7 +72,7 @@ public:
 protected:
   void Init(); // the real constructor
   void AddMCPhoton(DS::MCPMT* rat_mcpmt, const GLG4HitPhoton* photon,
-                   bool isDarkHit=false, EventInfo* exinfo=NULL);
+                   bool isDarkHit=false, EventInfo* exinfo=NULL, std::string process="unknown");
   
     /* Storing optical creation track ID and step */
   void PhotonRecurse(std::vector<int> &PhotonIDs, int trackID, int &parentID, int &firstCreatedID);
@@ -101,6 +101,8 @@ protected:
   double fNnoise;
   double noiseRate;
   double channelEfficiency;
+
+  std::map<int, std::string> trackProcessMap;
 
   bool fInitialStoreTrajectoryState;
 

--- a/src/ds/include/RAT/DS/MCPhoton.hh
+++ b/src/ds/include/RAT/DS/MCPhoton.hh
@@ -69,6 +69,12 @@ public:
   virtual void SetTrackID(Int_t _trackID){ trackID = _trackID;}
   virtual Int_t GetTrackID() const { return trackID; }
 
+  /** Name of physics process acting at endpoint of the MCTrackStep
+   * that created this photon hit. 
+   */
+  virtual std::string GetProcess() const { return process; }
+  virtual void SetProcess(const std::string &_process) { process = _process; }
+
   ClassDef(MCPhoton, 1) 
 
 protected:
@@ -82,6 +88,7 @@ protected:
   Float_t charge;
   Bool_t isDarkHit;
   Int_t trackID;
+  std::string process;
 };
 
   } // namespace DS

--- a/src/ds/include/RAT/DS/MCPhoton.hh
+++ b/src/ds/include/RAT/DS/MCPhoton.hh
@@ -75,7 +75,7 @@ public:
   virtual std::string GetProcess() const { return process; }
   virtual void SetProcess(const std::string &_process) { process = _process; }
 
-  ClassDef(MCPhoton, 1) 
+  ClassDef(MCPhoton, 2) 
 
 protected:
   Double_t hitTime;


### PR DESCRIPTION
Add an extra `Process` member to `MCPhoton` to store the creation process as either Scintillation, Cerenkov or Reemission.
`Process` is pulled directly from the `MCTrackStep` used to create the `MCPhoton`.
Allows matching PMT hits without storing all tracking information.