### PR TITLE
LazyMake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+# Makefile for the lazy
+
+build_directory := build
+
+all:
+	cmake . -B$(build_directory)
+	cmake --build $(build_directory) -- $(MAKEFLAGS)
+
+clean:
+	rm -rf $(build_directory)


### PR DESCRIPTION
We all know typing two commands to compile is cumbersome, this
saves us some keystrokes! No more typing
```
cmake . -Bbuild
cmake --build build
```
Now simply type `make -j9000`! Also comes with a handy `make clean`

... caution ... DO NOT use -j9000 ...