### PR TITLE
SplitEVDAQ Charge was adding quadratically, this fixes that

### DIFF
--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -148,10 +148,11 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
           {
             pmtInEvent = true;
             hitTimes.push_back(time);
-            integratedCharge += mcpmt->GetCharge();
+            integratedCharge += photon->GetCharge();
           }
         }
       }
+      std::sort(hitTimes.begin(), hitTimes.end());
       if( pmtInEvent )
       {
         DS::PMT* pmt = ev->AddNewPMT();


### PR DESCRIPTION
I was adding the mcpmt total charge for each photon instead of the charge from that photon. So a hit with 1 hit had ~1 charge, but 2 hits had 4, n hits had n^2 ...

Fixed now.