### PR TITLE
Adds absolute time at start of run

### DIFF
--- a/src/core/include/RAT/Gsim.hh
+++ b/src/core/include/RAT/Gsim.hh
@@ -88,6 +88,7 @@ protected:
 
   int runID;
   TTimeStamp utc;
+  TTimeStamp runutc;
   int maxpe;
   int nabort;
 

--- a/src/core/include/RAT/Gsim.hh
+++ b/src/core/include/RAT/Gsim.hh
@@ -88,7 +88,6 @@ protected:
 
   int runID;
   TTimeStamp utc;
-  TTimeStamp startTime;
   int maxpe;
   int nabort;
 

--- a/src/core/include/RAT/Gsim.hh
+++ b/src/core/include/RAT/Gsim.hh
@@ -88,7 +88,7 @@ protected:
 
   int runID;
   TTimeStamp utc;
-  TTimeStamp runutc;
+  TTimeStamp startTime;
   int maxpe;
   int nabort;
 

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -184,7 +184,6 @@ void Gsim::BeginOfRunAction(const G4Run* /*aRun*/) {
     DBLinkPtr lmc = DB::Get()->GetLink("MC");
     runID = DB::Get()->GetDefaultRun();
     utc = TTimeStamp();  // default to now
-    startTime = TTimeStamp(); 
 
     info << "Gsim: Simulating run " << runID << newline;
     info << "Gsim: Run start at " << utc.AsString() << newline;
@@ -448,7 +447,7 @@ void Gsim::MakeRun(int _runID) {
     
     run->SetID(_runID);
     run->SetType((unsigned)lrun->GetI("runtype"));
-    run->SetStartTime(startTime); 
+    run->SetStartTime(utc); 
     run->SetPMTInfo(&GeoPMTFactoryBase::GetPMTInfo());
     
     DS::RunStore::AddNewRun(run);

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -184,7 +184,7 @@ void Gsim::BeginOfRunAction(const G4Run* /*aRun*/) {
     DBLinkPtr lmc = DB::Get()->GetLink("MC");
     runID = DB::Get()->GetDefaultRun();
     utc = TTimeStamp();  // default to now
-    runutc = TTimeStamp(); 
+    startTime = TTimeStamp(); 
 
     info << "Gsim: Simulating run " << runID << newline;
     info << "Gsim: Run start at " << utc.AsString() << newline;
@@ -448,7 +448,7 @@ void Gsim::MakeRun(int _runID) {
     
     run->SetID(_runID);
     run->SetType((unsigned)lrun->GetI("runtype"));
-    
+    run->SetStartTime(startTime); 
     run->SetPMTInfo(&GeoPMTFactoryBase::GetPMTInfo());
     
     DS::RunStore::AddNewRun(run);
@@ -462,7 +462,6 @@ void Gsim::MakeEvent(const G4Event* g4ev, DS::Root* ds) {
     ds->SetRunID(theRunManager->GetCurrentRun()->GetRunID());
     mc->SetID(g4ev->GetEventID());
     mc->SetUTC(exinfo->utc);
-    mc->SetRunUTC(runutc);
  
     // Vertex Info
     for (int ivert = 0; ivert < g4ev->GetNumberOfPrimaryVertex(); ivert++) {

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -184,7 +184,8 @@ void Gsim::BeginOfRunAction(const G4Run* /*aRun*/) {
     DBLinkPtr lmc = DB::Get()->GetLink("MC");
     runID = DB::Get()->GetDefaultRun();
     utc = TTimeStamp();  // default to now
-    
+    runutc = TTimeStamp(); 
+
     info << "Gsim: Simulating run " << runID << newline;
     info << "Gsim: Run start at " << utc.AsString() << newline;
     
@@ -461,7 +462,8 @@ void Gsim::MakeEvent(const G4Event* g4ev, DS::Root* ds) {
     ds->SetRunID(theRunManager->GetCurrentRun()->GetRunID());
     mc->SetID(g4ev->GetEventID());
     mc->SetUTC(exinfo->utc);
-    
+    mc->SetRunUTC(runutc);
+ 
     // Vertex Info
     for (int ivert = 0; ivert < g4ev->GetNumberOfPrimaryVertex(); ivert++) {
         G4PrimaryVertex* pv = g4ev->GetPrimaryVertex(ivert);

--- a/src/ds/include/RAT/DS/MC.hh
+++ b/src/ds/include/RAT/DS/MC.hh
@@ -53,10 +53,6 @@ public:
   virtual TTimeStamp GetUTC() const { return utc; }
   virtual void SetUTC(const TTimeStamp& _utc) { utc = _utc; }
   
-  /** Absolute time of start of run. */
-  virtual TTimeStamp GetRunUTC() const { return runutc; }
-  virtual void SetRunUTC(const TTimeStamp& _runutc) { runutc = _runutc; }
-    
   /** Initial particles in event */
   virtual MCParticle* GetMCParticle(Int_t i) { return &particle[i]; }
   virtual int GetMCParticleCount() const { return particle.size(); }
@@ -131,7 +127,6 @@ protected:
   int numPE;
   int numDarkHits;
   TTimeStamp utc;
-  TTimeStamp runutc;
   std::vector<MCSummary> summary;
   std::vector<MCParticle> particle;
   std::vector<MCParticle> parent;

--- a/src/ds/include/RAT/DS/MC.hh
+++ b/src/ds/include/RAT/DS/MC.hh
@@ -52,7 +52,11 @@ public:
   /** Absolute time of event. */
   virtual TTimeStamp GetUTC() const { return utc; }
   virtual void SetUTC(const TTimeStamp& _utc) { utc = _utc; }
-      
+  
+  /** Absolute time of start of run. */
+  virtual TTimeStamp GetRunUTC() const { return runutc; }
+  virtual void SetRunUTC(const TTimeStamp& _runutc) { runutc = _runutc; }
+    
   /** Initial particles in event */
   virtual MCParticle* GetMCParticle(Int_t i) { return &particle[i]; }
   virtual int GetMCParticleCount() const { return particle.size(); }
@@ -127,6 +131,7 @@ protected:
   int numPE;
   int numDarkHits;
   TTimeStamp utc;
+  TTimeStamp runutc;
   std::vector<MCSummary> summary;
   std::vector<MCParticle> particle;
   std::vector<MCParticle> parent;

--- a/src/ds/include/RAT/DS/Run.hh
+++ b/src/ds/include/RAT/DS/Run.hh
@@ -11,7 +11,7 @@
 #include <RAT/DS/PMTInfo.hh>
 #include <TObject.h>
 #include <vector>
-#include <time.h>
+#include <TTimeStamp.h>
 
 namespace RAT {
   namespace DS {
@@ -30,8 +30,8 @@ public:
   virtual void SetType(ULong64_t _type) { type = _type; }
 
   /** Run start time */
-  virtual time_t GetStartTime() const { return startTime; }
-  virtual void SetStartTime(time_t _startTime) { startTime = _startTime; }
+  virtual TTimeStamp GetStartTime() const { return startTime; }
+  virtual void SetStartTime(const TTimeStamp& _startTime) { startTime = _startTime; }
 
   /** PMT information */
   virtual PMTInfo* GetPMTInfo() {
@@ -54,7 +54,7 @@ public:
 protected:
   Int_t id;
   ULong64_t type;
-  time_t startTime;
+  TTimeStamp startTime;
   std::vector<PMTInfo> pmtinfo;
 };
 

--- a/src/ds/include/RAT/DS/Run.hh
+++ b/src/ds/include/RAT/DS/Run.hh
@@ -49,7 +49,7 @@ public:
   virtual bool ExistPMTInfo() { return !pmtinfo.empty(); }
   virtual void PrunePMTInfo() { pmtinfo.resize(0); }
 
-  ClassDef(Run, 1)
+  ClassDef(Run, 2)
 
 protected:
   Int_t id;


### PR DESCRIPTION
For assessing time coincidence for accidental evaluation.