### PR TITLE
Wrap PMT geometry in cylindrical envelope to speed up processing

### DIFF
--- a/src/geo/src/GeoPMTFactoryBase.cc
+++ b/src/geo/src/GeoPMTFactoryBase.cc
@@ -288,7 +288,7 @@ namespace RAT {
         } catch (DBNotFoundError &e) { }
 
         // Build PMT
-        pmtParam.useEnvelope = false; // disable the use of envelope volume for now
+        pmtParam.useEnvelope = true; // enable the use of envelope volume for now (not used in standard rat-pac)
         PMTConstruction pmtConstruct(pmtParam);
 
         G4LogicalVolume *logiPMT = pmtConstruct.NewPMT(volume_name, vis_simple);
@@ -488,7 +488,7 @@ namespace RAT {
         // id - the nth pmt that GeoPMTFactoryBase has built
         for (int idx = start_idx, id = pmtinfo.GetPMTCount(); idx <= end_idx; idx++, id++) {
 
-            string pmtname = volume_name + ::to_string(id); //internally PMTs are represented by the nth pmt built, not pmtid
+            string pmtname = volume_name + "_pmtenv_" + ::to_string(id); //internally PMTs are represented by the nth pmt built, not pmtid
 
             // position
             G4ThreeVector pmtpos(pmt_x[idx], pmt_y[idx], pmt_z[idx]);

--- a/src/geo/src/GeoPMTParser.cc
+++ b/src/geo/src/GeoPMTParser.cc
@@ -144,7 +144,7 @@ namespace RAT {
       fParam.detector = 0;
 
 
-    fParam.useEnvelope = false; // disable the use of envelope volume for now
+    fParam.useEnvelope = true; // enable the use of envelope volume for now
     fConstruction = new PMTConstruction(fParam);
   }
 

--- a/src/physics/include/RAT/GLG4PMTOpticalModel.hh
+++ b/src/physics/include/RAT/GLG4PMTOpticalModel.hh
@@ -159,6 +159,7 @@ private:
   void CalculateCoefficients(); // calculate and set fR_s, etc.
   void Reflect(G4ThreeVector &dir, G4ThreeVector &pol, G4ThreeVector &norm);
   void Refract(G4ThreeVector &dir, G4ThreeVector &pol, G4ThreeVector &norm);
+  int GetPMTID(const G4FastTrack& fastTrack);
 
   static double surfaceTolerance;
 


### PR DESCRIPTION
tl;dr: Switched on a flag to wrap PMT in envelope, code speeds up, output looks consistent with output pre change.

I'm going to go into a fair bit of detail to preserve the process of trying to fix the worst bug I've ever had to deal with:

- Initial issue #53, generating points in center of the detector was very slow.

- Found that the slowness seemed to be a function of the distance from the PMTs, the number of PMTs in the geometry and the number of photons in the event.

- Guessed that it must be something to do with the interaction between the photons and the PMT geometry but couldn't find anything obvious in the code.

- Ran callgrind to try to find the culprit, found that a geant4 function called `SafetyForVoxelHeader` was being recursively called a lot.

![Screenshot 2020-08-26 at 18 54 13](https://user-images.githubusercontent.com/12896404/91339069-da991980-e7cd-11ea-8c21-594897b0d413.png)

- Looked at the g4 code and it seems that at each point in the photon tracking g4 finds the distance to the nearest surface, something is wrong with the PMT geometry where it doesn't stop at the outer surface, it checks all the internal components for the PMT too.

- I noticed that in `GeoPMTFactoryBase` there was a flag called `useEnvelope`, switching this on wraps the PMT geometry logical volumes in a cylindrical physical volume which I guess acts as a consistent outer surface (this is mentioned a little here: https://github.com/rat-pac/rat-pac/issues/33).

- Switching on the flag massively reduced the simulation time but set all of the PMT IDs to zero.

- I wasn't sure if this was a fixable issue as the flag is hardcoded to false in the original rat-pac and there have been a lot of updates to the PMT geometry which aren't in the watchman rat-pac.

- I added in all of the PMT updates from the original rat-pac (mostly described here: https://github.com/rat-pac/rat-pac/pull/37) but didn't see any real change to the performance without the envelope flag.

- I reverted the PMT updates again because I found an unmerged commit (https://github.com/rat-pac/rat-pac/pull/41) which solved the problem of the PMT IDs being set to zero.

The simulation seems to give the same output (3 MeV positrons distributed evenly in detector):
![charge](https://user-images.githubusercontent.com/12896404/91340757-70ce3f00-e7d0-11ea-866a-ddd4c09de92c.png)
![time](https://user-images.githubusercontent.com/12896404/91340771-7592f300-e7d0-11ea-8a22-cf24f4e9dc1b.png)
![pmtid](https://user-images.githubusercontent.com/12896404/91340782-788de380-e7d0-11ea-9b53-50903bcd377e.png)

I am still a little worried because the flag is hardcoded to false in the original rat-pac which makes me think that it might have never worked as intended and the fix I found is from a commit that isn't directly related to the envelope.

Output seems ok, but I'd feel bad if this broke a whole production so it would probably be a good idea to run it through the whole analysis pipeline to make sure it doesn't break something deep down.