### PR TITLE
Database updates to pass array arguments

### DIFF
--- a/src/cmd/src/GLG4DebugMessenger.cc
+++ b/src/cmd/src/GLG4DebugMessenger.cc
@@ -337,9 +337,9 @@ SetNewValue(G4UIcommand * command,G4String newValues)
       int value = new_value != 0.0 ? 0 : 1; // invert meaning
 
       if (parameterName == "omit_muon_processes") {
-        db->SetI("MC", "", "muon_processes", value);
+        db->Set("MC", "", "muon_processes", value);
       } else if (parameterName == "omit_hadronic_processes") {
-        db->SetI("MC", "", "hadronic_processes", value);
+        db->Set("MC", "", "hadronic_processes", value);
       } else {
         RAT::Log::Die(dformat("/glg4debug/glg4param has been deprecated and '%s' is unsupported", parameterName.c_str()));
       }

--- a/src/db/include/RAT/DB.hh
+++ b/src/db/include/RAT/DB.hh
@@ -71,7 +71,7 @@ DB *db = DB::Get();
 DBLinkPtr lmedia = db->GetLink("MEDIA", "acrylic");  // Link to MEDIA[acrylic]
 double rindex = lmedia->GetD("index_of_refraction");
 @endcode
- *
+ *  
  *  You can hold onto DBLinkPtr objects as long as you like.  If
  *  you expect you will need to access the same table at various
  *  points in your code, you can obtain a link pointer in your
@@ -88,31 +88,33 @@ double rindex = lmedia->GetD("index_of_refraction");
 #include <set>
 #include <deque>
 #include <RAT/HTTPDownloader.hh>
-#include <RAT/DBLink.hh>
 #include <RAT/DBFieldCallback.hh>
 #include <RAT/smart_ptr.hpp>
+#include <RAT/Log.hh>
+#include <RAT/DBTable.hh>
 
 namespace RAT {
 
 
 class DB; // Forward decl to allow for static DB member inside itself
 class DBTable;
+class DBLink;
 
 class DBTableKey {
 public:
   DBTableKey() : name(""), index(""), run(0) {};
   DBTableKey (const std::string &_name, const std::string &_index, const int _run=0)
     : name(_name), index(_index), run(_run) {};
-
+  
   std::string name;
   std::string index;
   int run;
-
+  
   bool operator< (const DBTableKey &rhs) const {
-    return (name < rhs.name) || (name == rhs.name && index < rhs.index)
+    return (name < rhs.name) || (name == rhs.name && index < rhs.index) 
       || (name == rhs.name && index == rhs.index && run < rhs.run);
   };
-
+  
   bool operator== (const DBTableKey &rhs) const {
     return (name == rhs.name) && (index == rhs.index) && (run == rhs.run);
   };
@@ -145,12 +147,12 @@ public:
    *  @param[out] table       Just the table name
    *  @param[out] index       Just the index name.  Empty string if no
    *  index.
-   *
+   * 
    *  @returns True if @p descriptor was a properly formatted table name.
    */
-  static bool ParseTableName(std::string descriptor,
+  static bool ParseTableName(std::string descriptor, 
 			     std::string &table, std::string &index);
-
+			     
 	/** Reads a file and returns all the RATDB tables found inside.
 	 *  Works with both RATDB native and JSON files */
   static std::vector<RAT::DBTable *> ReadRATDBFile(const std::string &filename);
@@ -181,12 +183,12 @@ public:
    */
   int Load(std::string filename, bool printPath=false);
 
-  /** Put a DBTable into the database.  Returns 1 if success and 0 if failure.
+  /** Put a DBTable into the database.  Returns 1 if success and 0 if failure. 
    The DB class will take over responsibility for freeing the table memory
    when needed. */
   int LoadTable(DBTable *table);
 
-  /** Load DB text file of tables into memory.
+  /** Load DB text file of tables into memory. 
    *
    *  This function does not search in $GLG4DATA automatically, so it
    *  must be given a file name relative to the current directory or
@@ -204,7 +206,7 @@ public:
 
   /** Load standard tables into memory.
    *
-   *  Currently, the standard tables are $GLG4DATA/ *.ratdb.
+   *  Currently, the standard tables are $GLG4DATA/ *.ratdb. 
    */
   int LoadDefaults();
 
@@ -220,7 +222,7 @@ public:
   /** Get the default run number used for new links **/
   int GetDefaultRun() const;
 
-  /** Obtain a link to a particular table and index with default run.
+  /** Obtain a link to a particular table and index with default run. 
    *
    *  Note that even if your table does not have an index value,
    *  you should still use this method, but with an empty index.
@@ -228,7 +230,7 @@ public:
    */
   DBLinkPtr GetLink(std::string tblname, std::string index="");
 
-  /** Obtain a link to a particular table and index with given run.
+  /** Obtain a link to a particular table and index with given run. 
    *
    *  If you have an empty index, pass "" as the index value.
    */
@@ -237,7 +239,7 @@ public:
 
   /** Obtain a link to all tables with the same name, but different
    *  indexes.
-   *
+   * 
    *  LinkGroups are useful if you want to step through all the
    *  instances of the same kind of table, like GEO.
    */
@@ -247,45 +249,18 @@ public:
   // DO THIS AFTER loading files from disk, or your changes will be
   // stomped on later.
 
-  /** Set integer field in user plane, no table index. */
-  void SetI(std::string tblname, std::string fieldname, int val)
-  { SetI(tblname, "", fieldname, val); };
+  /** Set field in user plane, no table index. */
+  template <typename T> void Set(const std::string &tblname, const std::string &fieldname, const T &val);
+  
+  /** Set field in user plane, with table index. */
+  template <typename T> void Set(const std::string &tblname, const std::string &index, const std::string &fieldname, const T &val);
 
-  /** Set integer field in user plane, with table index. */
-  void SetI(std::string tblname, std::string index, std::string fieldname, int val);
-
-  /** Set double field in user plane, no table index. */
-  void SetD(std::string tblname, std::string fieldname, double val)
-  { SetD(tblname, "", fieldname, val); };
-  /** Set double field in user plane, with table index. */
-  void SetD(std::string tblname, std::string index, std::string fieldname, double val);
-
-  /** Set string field in user plane, no table index. */
-  void SetS(std::string tblname, std::string fieldname, std::string val)
-  { SetS(tblname, "", fieldname, val); };
-  /** Set string field in user plane, with table index. */
-  void SetS(std::string tblname, std::string index, std::string fieldname, std::string val);
-
-
-  /** Set integer array field in user plane, no table index. */
-  void SetIArray(std::string tblname, std::string fieldname, const std::vector<int> &val)
-  { SetIArray(tblname, "", fieldname, val); };
-  /** Set integer array field in user plane, with table index. */
-  void SetIArray(std::string tblname, std::string index, std::string fieldname, const std::vector<int> &val);
-
-  /** Set double array field in user plane, no table index. */
-  void SetDArray(std::string tblname, std::string fieldname, const std::vector<double> &val)
-  { SetDArray(tblname, "", fieldname, val); };
-  /** Set double array field in user plane, with table index. */
-  void SetDArray(std::string tblname, std::string index, std::string fieldname, const std::vector<double> &val);
-
-  /** Set string array field in user plane, no table index. */
-  void SetSArray(std::string tblname, std::string fieldname, const std::vector<std::string> &val)
-  { SetSArray(tblname, "", fieldname, val); };
-  /** Set string array field in user plane, with table index. */
-  void SetSArray(std::string tblname, std::string index, std::string fieldname, const std::vector<std::string> &val);
-
-
+  /** Set array field index in user plane, no table index. */
+  template <typename T> void SetArrayIndex(const std::string &tblname, const std::string &fieldname, size_t idx, const T &val);
+  
+  /** Set array field index in user plane, with table index. */
+  template <typename T> void SetArrayIndex(const std::string &tblname, const std::string &index, const std::string &fieldname, size_t idx, const T &val);
+  
   /************************DBLink interface********************/
   // This is the low level interface that DBLinks use.
   // You should not call these methods.
@@ -299,7 +274,7 @@ public:
       what you are doing! */
   DBTable *GetRunTable(std::string tblname, std::string index, int runNumber)
       { return FindTable(tblname, index, runNumber); };
-
+      
   /** Get pointer to a table in default plane: do not use unless you know
       what you are doing! */
   DBTable *GetDefaultTable(std::string tblname, std::string index)
@@ -322,12 +297,12 @@ public:
    *  for debugging purposes.
    */
   int NumLinks() { return links.size(); };
-
+  
   virtual std::vector<int> FetchIArray(const std::string &tableID, const std::string &fieldname);
   virtual std::vector<double> FetchDArray(const std::string &tableID, const std::string &fieldname);
-
+  
 protected:
-  /** Obtain a pointer to a table loaded in memory.
+  /** Obtain a pointer to a table loaded in memory. 
    *
    *  @returns Pointer to table if found, otherwise 0.
    */
@@ -335,7 +310,7 @@ protected:
 
   /** Obtain a pointer to a table in memory, or create it if
    *  not found.
-   *
+   * 
    *  @returns Pointer to existing table, or pointer to new table,
    *  which is also added to @p tblset.
    */
@@ -358,21 +333,21 @@ protected:
   /** URL to CouchDB server.  Empty string means no server will be
    *  used. */
   std::string server;
-
+  
   /** Cache of table names present on the CouchDB server.  Check this before issuing a query. */
   std::set<std::string> tableNamesOnServer;
-
+  
   /** Cache of full table keys (name, index, run) that are *not* on the server.
       Important to cut down on needless network traffic from future queries once
       a rejection has been received. */
   std::set<RAT::DBTableKey> tablesNotOnServer;
-
+  
   /** Helper class to download files over HTTP/HTTPS */
   HTTPDownloader downloader;
 
   /** Set of all tables.  Run 0 signifies default and run -1 is user-override. */
   DBTableSet tables;
-
+  
   /** FIFO of tables fetched from the server.  Second element of pair is
       indicates if the size from this key "is real".  When the same table
       is added for multiple runs, only the last run should be set to true. */
@@ -383,5 +358,35 @@ protected:
 };
 
 } // namespace RAT
+
+// Unfortunately necessary to include this after definition of DB to avoid circular references
+#include <RAT/DBLink.hh>
+
+  template <typename T> void RAT::DB::Set(const std::string &tblname, const std::string &fieldname, const T &val) {
+    Set(tblname, "", fieldname, val); 
+  }
+
+  /** Set field in user plane, with table index. */
+  template <typename T> void RAT::DB::Set(const std::string &tblname, const std::string &index, const std::string &fieldname, const T &val) {
+    DBTable *t = FindOrCreateTable(tblname, index, -1);
+    t->Set(fieldname, val);
+  }
+
+  /** Set array field index in user plane, no table index. */
+  template <typename T> void RAT::DB::SetArrayIndex(const std::string &tblname, const std::string &fieldname, size_t idx, const T &val) { 
+    SetArrayIndex(tblname, "", fieldname, idx, val); 
+  }
+  
+  /** Set array field index in user plane, with table index. */
+  template <typename T> void RAT::DB::SetArrayIndex(const std::string &tblname, const std::string &index, const std::string &fieldname, size_t idx, const T &val) {
+    DBTable *t = FindOrCreateTable(tblname, index, -1);
+    DBLinkPtr p = GetLink(tblname,index); //This ensures we always grab either the previously set or default plane array without keeping track explicitly
+    json::Value jval = p->Get<json::Value>(fieldname);
+    Log::Assert(jval.getType() == json::TARRAY,"RATDB: Cannot set an index for an item that is not an array!");
+    jval[index] = val;
+    t->Set(fieldname,jval);
+  }
+
+
 
 #endif

--- a/src/db/include/RAT/DBLink.hh
+++ b/src/db/include/RAT/DBLink.hh
@@ -39,13 +39,13 @@
 
 #include <string>
 #include <vector>
+#include <RAT/DB.hh>
 #include <RAT/DBTable.hh>
 
 namespace RAT {
 
 
 class DB;
-
 
 class DBLink {
 public:
@@ -97,6 +97,13 @@ public:
    */
   std::string GetS(const std::string &name);
 
+  /** Retrieve bool field.
+   *
+   *  @throws DBNotFoundException if string field @p name does not
+   *  exist.
+   */
+  bool GetZ(const std::string &name);
+
   /** Retrieve integer array field.
    *
    *  @throws DBNotFoundException if integer array field @p name
@@ -127,31 +134,34 @@ public:
    */  
   std::vector<std::string> GetSArray(const std::string &name);
 
+  /** Retrieve bool array field.
+   *
+   *  @throws DBNotFoundException if string array field @p name
+   *  does not exist.
+   */  
+  std::vector<bool> GetZArray(const std::string &name);
+
   /** Retrieve raw JSON value.
    *
    *  @throws DBNotFoundException if field @p name
    *  does not exist.
    */  
   json::Value GetJSON(const std::string &name);
+  
 
-
+  /** Get the value of a field from the table, including plane
+   *  precedence rules.
+   *
+   *  @param  T          C++ data type for field
+   *  @param  fieldname  Name of field
+   */
+  template <class T> T Get(const std::string &fieldname);
+  
   // Used by DB class, do not use this yourself
   void Unlink() { db = 0; };
 
 protected:
 
-  /** Get the value of a field from the table, including plane
-   *  precedence rules.
-   *
-   *  This method is implemented as a template method to save having
-   *  to write 8 Pick methods.
-   *
-   *  @param  T          C++ data type for field
-   *  @param  fieldname  Name of field
-   *  @param  ftype      DB type for field 
-   */
-  template <class T> 
-  T Pick(std::string fieldname, DBTable::FieldType ftype) const;
 
   /** Pointer to DB which created this link. */
   DB *db;
@@ -165,6 +175,34 @@ protected:
   /** Current run number */
   int currentRun;
 };
+
+  template <class T> T DBLink::Get(const std::string &fieldname) {
+  
+    DBTable *tbl;
+    // First try user plane
+    tbl = db->GetUserTable(tblname, index);
+    if (!tbl || tbl->GetFieldType(fieldname) == DBTable::NOTFOUND) {
+      // Then try the run plane
+      tbl = db->GetRunTable(tblname, index, currentRun);
+      if (tbl) { 
+        if (tbl->GetFieldType(fieldname) == DBTable::NOTFOUND) throw DBNotFoundError(tblname, index, fieldname);
+      } else {
+        // Finally try default plane
+        tbl = db->GetDefaultTable(tblname, index);
+        if (!tbl || tbl->GetFieldType(fieldname) == DBTable::NOTFOUND) {
+          throw DBNotFoundError(tblname, index, fieldname);
+        }
+      }
+    }
+
+    // Make class explicit to satisfy Sun CC 5.3
+    T value = tbl->DBTable::Get<T>(fieldname);
+
+    // Trace DB accesses
+    Log::TraceDBAccess(tblname, index, fieldname, value);
+
+    return value;
+  }
 
 
 } // namespace RAT

--- a/src/db/include/RAT/json.hh
+++ b/src/db/include/RAT/json.hh
@@ -25,20 +25,20 @@
 #include <sstream>
 
 namespace json {
-    
+
     class Value;
     class Reader;
     class Writer;
 
     //types used by Value
-    typedef int TInteger;
-    typedef unsigned int TUInteger;
+    typedef long int TInteger;
+    typedef unsigned long int TUInteger;
     typedef double TReal;
     typedef bool TBool;
     typedef std::string TString;
     typedef std::map<TString,Value> TObject;
     typedef std::vector<Value> TArray;
-    
+
     typedef union {
         //basic types by value
         TInteger integer;
@@ -46,7 +46,7 @@ namespace json {
         TReal real;
         TBool boolean;
         //structured types by reference
-        TString *_string;
+        TString *string;
         TObject *object;
         TArray *array;
     } TData;
@@ -62,29 +62,36 @@ namespace json {
         TARRAY,
         TNULL
     };
-    
+
     //JSON Value container class. Basic types (int,uint,real,bool) are stored by value, and structured types are stored by reference.
     class Value {
-    
+
         friend class Reader;
         friend class Writer;
-        
+
         public:
-        
+
             // Default constructs null Value (this is fast)
             inline Value() : refcount(NULL), type(TNULL) { }
-            
+
+            // Initilize to be of a specific type
+            inline Value(Type type_) : refcount(NULL), type(TNULL) { reset(type_); }
+
             // Construct values directly from basic types. These are passed by value and have no refcount.
             explicit inline Value(TInteger integer) : refcount(NULL), type(TINTEGER) { data.integer = integer; }
             explicit inline Value(TUInteger uinteger) : refcount(NULL), type(TUINTEGER) { data.uinteger = uinteger; }
             explicit inline Value(TReal real) : refcount(NULL), type(TREAL) { data.real = real; }
             explicit inline Value(TBool boolean) : refcount(NULL), type(TBOOL) { data.boolean = boolean; }
-            
+
+            // All these integer types... force them into our types
+            explicit inline Value(unsigned int uinteger) : refcount(NULL), type(TUINTEGER) { data.uinteger = (TUInteger)uinteger; }
+            explicit inline Value(int integer) : refcount(NULL), type(TINTEGER) { data.integer = (TInteger)integer; }
+
             // Construct structured types. These values are copied into the Value and subsequently passed by reference with refcount.
-            explicit inline Value(TString string) : refcount(new TUInteger(0)), type(TSTRING) { data._string = new TString(string); }
+            explicit inline Value(TString string) : refcount(new TUInteger(0)), type(TSTRING) { data.string = new TString(string); }
             explicit inline Value(TObject object) : refcount(new TUInteger(0)), type(TOBJECT) { data.object = new TObject(object); }
             explicit inline Value(TArray array) : refcount(new TUInteger(0)), type(TARRAY) { data.array = new TArray(array); }
-            
+
             // Constructs a JSON array from a vector (assuming the compile type conversions are possible)
             template <typename T> Value(const std::vector<T> &ref) : refcount(new TUInteger(0)), type(TARRAY) {
                 const size_t size = ref.size();
@@ -93,52 +100,52 @@ namespace json {
                     (*data.array)[i] = Value(ref[i]);
                 }
             }
-            
+
             // Copy constructor - preserves structured types and refcount tracking
             inline Value(const Value &other) : refcount(other.refcount), type(other.type), data(other.data) { incref(); }
-            
+
             // Destructor handles refcount tracking of structured types
             inline ~Value() { decref(); }
-            
+
             // Sets the lhs equal to the value (for base types) or reference (for structured types)
             inline Value& operator=(const Value& other) { decref(); data = other.data; type = other.type; refcount = other.refcount; incref(); return *this; }
             template <typename T> inline Value& operator=(const T& val) { return operator=(Value(val)); }
-            
+
             inline Value& operator[](const std::string &key) const { return getMember(key); }
             inline Value& operator[](const size_t index) const { return getIndex(index); }
-            
+
             // Initializes the state of the Value to the default for structured types or unspecified for basic types
             void reset(Type type);
-            
+
             // Sets the value to null
             inline void reset() { reset(TNULL); }
-            
+
             // Returns the type of the Value
             inline Type getType() const { return type; }
-            
+
             // Getters will throw a parser_error if the type of the Value is not the requested type
             inline TInteger getInteger() const { checkType(TINTEGER); return data.integer; }
             inline TUInteger getUInteger() const { checkType(TUINTEGER); return data.uinteger; }
             inline TReal getReal() const { checkType(TREAL); return data.real; }
             inline TBool getBool() const { checkType(TBOOL); return data.boolean; }
-            inline TString getString() const { checkType(TSTRING); return *data._string; }
-            
+            inline TString getString() const { checkType(TSTRING); return *data.string; }
+
             // Returns a member of a JSON object
             inline Value& getMember(TString key) const { checkType(TOBJECT); return (*data.object)[key]; }
-            
+
             // Returns the size of a JSON array
             inline size_t getArraySize() const { checkType(TARRAY); return data.array->size(); }
-            
+
             // Returns the Value at an index in a JSON array
             inline Value& getIndex(size_t index) const { checkType(TARRAY); return (*data.array)[index]; }
-            
+
 #ifndef __CINT__
 
-            // Templated casting functions (use these when possible / see below for default specializations) 
+            // Templated casting functions (use these when possible / see below for default specializations)
             template <typename T> inline T cast() const {
                 throw std::runtime_error("Cannot cast Value to desired type"); // Arbitrary type casts are impossible
             }
-            
+
             // Templated vector constructing method (uses templated casters to convert types)
             template <typename T> inline std::vector<T> toVector() const {
                 const size_t size = getArraySize(); //will check that we are an array
@@ -150,64 +157,64 @@ namespace json {
             }
 
 #endif
-            
+
             // Returns a vector of all the keys in the JSON object
             std::vector<std::string> getMembers() const;
-            
+
             // Returns true if the key exists in the JSON object
             bool isMember(std::string key) const;
-            
+
             // Setters will reset the type if necessary
             inline void setInteger(TInteger integer)  { checkTypeReset(TINTEGER); data.integer = integer; }
             inline void setUINteger(TUInteger uinteger) { checkTypeReset(TUINTEGER); data.uinteger = uinteger; }
             inline void setReal(TReal real) { checkTypeReset(TREAL); data.real = real; }
             inline void setReal(TBool boolean) { checkTypeReset(TBOOL); data.boolean = boolean; }
-            inline void setString(TString string) { checkTypeReset(TSTRING); *data._string = string; }
-            
-            // Sets a member of a JSON object 
+            inline void setString(TString string) { checkTypeReset(TSTRING); *data.string = string; }
+
+            // Sets a member of a JSON object
             inline void setMember(TString key, Value value) { checkTypeReset(TOBJECT); (*data.object)[key] = value; }
-            
-            // Sets the size of a JSON array 
+
+            // Sets the size of a JSON array
             inline void setArraySize(size_t size) { checkTypeReset(TARRAY); data.array->resize(size); }
-            
+
             // Sets the Value at an index in a JSON array
             inline void setIndex(size_t index, Value value) { checkTypeReset(TARRAY); (*data.array)[index] = value; }
-            
+
         protected:
-            
+
             // Returns a string representing the given type
             static std::string prettyType(Type type);
-            
+
             // Throws a nice error message for trying to get the wrong type
             static void wrongType(Type actual, Type requested);
-        
+
             // Throws a runtime_error if the type of the Value does not match the given Type
-            inline void checkType(Type _type) const { if (this->type != _type) { wrongType(this->type, _type); } }
-            
+            inline void checkType(Type type_) const { if (this->type != type_) { wrongType(this->type,type_); } }
+
             // Resets the type of Value of the current type does not match the given Type
-            inline void checkTypeReset(Type _type) { if (this->type != _type) reset(TOBJECT); }
-            
+            inline void checkTypeReset(Type type_) { if (this->type != type_) reset(TOBJECT); }
+
             // Decreases the refcount of the Value and cleans up if necessary
             inline void decref() { if (refcount && !((*refcount)--)) clean(); }
-            
+
             // Increases the refcount of the Value if necessary
             inline void incref() { if (refcount) (*refcount)++; }
-            
+
             // Frees any allocated memory for this object and resets to null
             void clean();
-        
+
             // Pointer to the number of references of a structured type
             TUInteger *refcount;
-            
+
             // The current type of the Value
             Type type;
-            
+
             // Union to hold the data with minimal space requirements
             TData data;
     };
-    
+
 #ifndef __CINT__
-    
+
     // Everything can be cast to a string in one way or another
     template <> inline std::string Value::cast<std::string>() const {
         switch (type) {
@@ -228,7 +235,7 @@ namespace json {
             case TNULL:
                 return "null";
             case TSTRING:
-                return *(data._string);
+                return *(data.string);
             case TARRAY: {
                 std::stringstream out; out << "ARR{" << (void*)data.array << '}';
                 return out.str();
@@ -241,8 +248,8 @@ namespace json {
                 throw std::runtime_error("Value could not be cast to string (forgotten?)");
         }
     }
-    
-    // Only integer Values can be cast as ints
+
+    // Only integer Values can be cast as ints (typically 32 bits)
     template <> inline int Value::cast<int>() const {
         switch (type) {
             case TUINTEGER:
@@ -253,9 +260,9 @@ namespace json {
                 throw std::runtime_error("Cannot cast " + prettyType(type) + " to integer");
         }
     }
-    
+
     // All numerics can be cast to doubles
-    template <> inline double Value::cast<double>() const { 
+    template <> inline double Value::cast<double>() const {
         switch (type) {
             case TUINTEGER:
                 return data.uinteger;
@@ -267,9 +274,9 @@ namespace json {
                 throw std::runtime_error("Cannot cast " + prettyType(type) + " to double");
         }
     }
-    
+
     // All Values are true except zero, false, and null
-    template <> inline bool Value::cast<bool>() const { 
+    template <> inline bool Value::cast<bool>() const {
         switch (type) {
             case TUINTEGER:
                 return data.uinteger != 0;
@@ -287,7 +294,7 @@ namespace json {
     }
 
 #endif
-    
+
     //represents errors in parsing JSON values
     class parser_error : public std::exception {
         public:
@@ -298,62 +305,65 @@ namespace json {
             const int line, pos;
             std::string desc, pretty;
     };
-    
+
     //parses JSON values from a stream
     class Reader {
         public:
-            //Reads the entire stream immediately
+            //Reads entire stream into internal buffer immediately
             Reader(std::istream &stream);
-            
-            //Copies the string into the internal buffer
+
+            //Copies the entire string into an internal buffer
             Reader(const std::string &str);
-            
+
             ~Reader();
-            
+
             //Returns the next value in the stream
             bool getValue(Value &result);
-            
+
         protected:
             //Positional data in the stream data (gets garbled during parsing)
             char *data,*cur,*lastbr;
             int line;
-            
+
             //Converts an escaped JSON string into its literal representation
             std::string unescapeString(std::string string);
-            
+
             //Helpers to read JSON types
             Value readNumber();
             Value readString();
             Value readObject();
             Value readArray();
-            
+
             void skipComment();
-    
+
     };
-    
+
     //writes JSON values to a stream
     class Writer {
         public:
             //Only writes to the stream when requested
             Writer(std::ostream &stream);
-            
+
             ~Writer();
-            
-            //Writes a value to the stream
-            void putValue(Value value);
-            
+
+            //This produces JSON compliant output at the expense of:
+            //***Unsigned integers get printed as base 10 numbers, and the next parser may truncate into signed
+            //Ultimately produces object-indented text with value-per-line mentality with arrays on a single line
+            //which is similar enough to how RATDB looks without too much effort.
+            void putValue(const Value &value);
+
         protected:
             //The stream to write to
             std::ostream &out;
-            
+
             //Converts a literal string to its escaped representation
             std::string escapeString(std::string string);
-            
+
             //Helper to write a value to the stream
-            void writeValue(Value value);
-    
-    };  
-    
+            void writeValue(const Value &value, const std::string &depth = "");
+
+    };
+
 }
 
 #endif

--- a/src/db/src/DB.cc
+++ b/src/db/src/DB.cc
@@ -404,6 +404,9 @@ DBTable *DB::FindTable(std::string tblname, std::string index, int runNumber)
     }
   }
   
+  /*
+  // This code was not actually doing anything because the bytes were not being 
+  // tracked before in the first place, but keep commented for historical reasons.
   // 5) Flush out some tables if we need the space
   int newTableBytes = newTable->GetBytes();
   int serverTableBytes = 0;
@@ -421,6 +424,7 @@ DBTable *DB::FindTable(std::string tblname, std::string index, int runNumber)
     tables.erase(forDeletion.first);
     cerr << "Evicting " << forDeletion.first.name << "[" << forDeletion.first.index << "], run " << forDeletion.first.run << " (" << deleteSize << " bytes)\n";
   }
+  */
     
   // 6) Add this table to the memory cache
   simple_ptr_nocopy<DBTable> newTablePtr(newTable);
@@ -441,45 +445,6 @@ DBTable *DB::FindTable(std::string tblname, std::string index, int runNumber)
 
   return newTable;
 }
-
-void DB::SetI(std::string tblname, std::string index, std::string fieldname, int val)
-{
-  DBTable *t = FindOrCreateTable(tblname, index, -1);
-  t->SetI(fieldname, val);
-}
-
-void DB::SetD(std::string tblname, std::string index, std::string fieldname, double val)
-{
-  DBTable *t = FindOrCreateTable(tblname, index, -1);
-  t->SetD(fieldname, val);
-}
-
-
-void DB::SetS(std::string tblname, std::string index, std::string fieldname, std::string val)
-{
-  DBTable *t = FindOrCreateTable(tblname, index, -1);
-  t->SetS(fieldname, val);
-}
-
-  
-void DB::SetIArray(std::string tblname, std::string index, std::string fieldname, const std::vector<int> &val)
-{
-  DBTable *t = FindOrCreateTable(tblname, index, -1);
-  t->SetIArray(fieldname, val);
-}
-
-void DB::SetDArray(std::string tblname, std::string index, std::string fieldname, const std::vector<double> &val)
-{
-  DBTable *t = FindOrCreateTable(tblname, index, -1);
-  t->SetDArray(fieldname, val);
-}
-
-void DB::SetSArray(std::string tblname, std::string index, std::string fieldname, const std::vector<std::string> &val)
-{
-  DBTable *t = FindOrCreateTable(tblname, index, -1);
-  t->SetSArray(fieldname, val);
-}
-
 
 DBTable *DB::FindOrCreateTable(std::string tblname, std::string index, int runNumber)
 {

--- a/src/db/src/DBLink.cc
+++ b/src/db/src/DBLink.cc
@@ -26,23 +26,29 @@ DBLink::~DBLink()
 
 int DBLink::GetI(const std::string &name)
 {
-  return Pick<int>(name, DBTable::INTEGER);
+  return Get<int>(name);
 }
 
 
 double DBLink::GetD(const std::string &name)
 {
-  return Pick<double>(name, DBTable::DOUBLE);
+  return Get<double>(name);
 }
 
 std::string DBLink::GetS(const std::string &name)
 {
-  return Pick<std::string>(name, DBTable::STRING);
+  return Get<std::string>(name);
 }
+
+bool DBLink::GetZ(const std::string &name)
+{
+  return Get<bool>(name);
+}
+
 
 std::vector<int> DBLink::GetIArray(const std::string &name)
 {
-  return Pick< std::vector<int> >(name, DBTable::INTEGER_ARRAY);
+  return Get<std::vector<int> >(name);
 }
 
 
@@ -70,55 +76,23 @@ std::vector<float> DBLink::DArrayToFArray(const std::vector<double> &input)
 
 std::vector<double> DBLink::GetDArray(const std::string &name)
 {
-  return Pick< std::vector<double> >(name, DBTable::DOUBLE_ARRAY);
+  return Get<std::vector<double> >(name);
 }
 
 std::vector<std::string> DBLink::GetSArray(const std::string &name)
 {
-  return Pick< std::vector<std::string> >(name, DBTable::STRING_ARRAY);
+  return Get<std::vector<std::string> >(name);
 }
+
+std::vector<bool> DBLink::GetZArray(const std::string &name)
+{
+  return Get<std::vector<bool> >(name);
+}
+
 
 json::Value DBLink::GetJSON(const std::string &name)
 {
-  return Pick< json::Value >(name, DBTable::JSON);
-}
-
-// Helper function to make Pick() easier to read
-// Type equality is as you would expect, but JSON equals everything except NOTFOUND
-inline bool equivalent(DBTable::FieldType a, DBTable::FieldType b)
-{
-  if (a == b) return true;
-  else if (a == DBTable::JSON && b != DBTable::NOTFOUND) return true;
-  else if (b == DBTable::JSON && a != DBTable::NOTFOUND) return true;
-  else return false;
-}
-
-template <class T>
-T DBLink::Pick(std::string fieldname, DBTable::FieldType ftype) const
-{
-  DBTable *tbl;
-  
-  // First try user plane
-  tbl = db->GetUserTable(tblname, index);
-  if (!tbl || !equivalent(tbl->GetFieldType(fieldname), ftype)) {
-    // Then try the run plane
-    tbl = db->GetRunTable(tblname, index, currentRun);
-    if(!tbl || !equivalent(tbl->GetFieldType(fieldname), ftype)) {
-      
-      // Finally try default plane
-      tbl = db->GetDefaultTable(tblname, index);
-      if (!tbl || !equivalent(tbl->GetFieldType(fieldname), ftype))
-        throw DBNotFoundError(tblname, index, fieldname);
-    }
-  }
-    
-  // Make class explicit to satisfy Sun CC 5.3
-  T value = tbl->DBTable::Get<T>(fieldname);
-
-  // Trace DB accesses
-  Log::TraceDBAccess(tblname, index, fieldname, value);
-  
-  return value;
+  return Get<json::Value>(name);
 }
 
 

--- a/src/db/src/DBTable.cc
+++ b/src/db/src/DBTable.cc
@@ -4,7 +4,7 @@ namespace RAT {
 
 
 DBTable::DBTable()
-  : tblname(""), index(""), run_begin(0), run_end(0), bytes(0)
+  : tblname(""), index(""), run_begin(0), run_end(0)
 {
   this->tblname = "";
   this->index = "";
@@ -12,7 +12,7 @@ DBTable::DBTable()
 }
 
 DBTable::DBTable(json::Value &jsonDoc)
-  : tblname(""), index(""), run_begin(0), run_end(0), bytes(0)
+  : tblname(""), index(""), run_begin(0), run_end(0)
 {
   tblname = jsonDoc["name"].cast<std::string>();
   if (jsonDoc.isMember("index"))
@@ -25,7 +25,7 @@ DBTable::DBTable(json::Value &jsonDoc)
 }
 
 DBTable::DBTable(std::string _tblname, std::string _index)  
-  : tblname(_tblname), index(_index), run_begin(0), run_end(0), bytes(0)
+  : tblname(_tblname), index(_index), run_begin(0), run_end(0)
 {
   table.reset(json::TOBJECT);
 }
@@ -46,8 +46,9 @@ DBTable::FieldType DBTable::GetFieldType(std::string name) const
     switch (val.getType()) {
         case json::TINTEGER:
         case json::TUINTEGER:
-        case json::TBOOL:
             return DBTable::INTEGER;
+        case json::TBOOL:
+            return DBTable::BOOLEAN;
         case json::TREAL:
             return DBTable::DOUBLE;
         case json::TSTRING:
@@ -57,8 +58,9 @@ DBTable::FieldType DBTable::GetFieldType(std::string name) const
                 switch (val[0].getType()) {
                     case json::TINTEGER:
                     case json::TUINTEGER:
-                    case json::TBOOL:
                         return DBTable::INTEGER_ARRAY;
+                    case json::TBOOL:
+                        return DBTable::BOOLEAN_ARRAY;
                     case json::TREAL:
                         return DBTable::DOUBLE_ARRAY;
                     case json::TSTRING:
@@ -122,27 +124,20 @@ std::string DBTable::GetS(const std::string &name) const {
         return table[name].cast<std::string>();
 }
 
-std::vector<std::string> DBTable::GetSArray(const std::string &name) const {
+bool DBTable::GetZ(const std::string &name) const {
     if (!table.isMember(name))
         throw DBNotFoundError(tblname, index, name);
-    else if (GetFieldType(name) != STRING_ARRAY)
-        throw DBWrongTypeError(tblname, index, name, STRING_ARRAY, GetFieldType(name));
+    else if (table[name].getType() != json::TBOOL)
+        throw DBWrongTypeError(tblname, index, name, BOOLEAN, GetFieldType(name));
     else
-        return table[name].toVector<std::string>();
-}
-
-json::Value DBTable::GetJSON(const std::string &name) const {
-    if (!table.isMember(name))
-        throw DBNotFoundError(tblname, index, name);
-    else
-        return table[name];
+        return table[name].cast<bool>();
 }
 
 std::vector<int> DBTable::GetIArray(const std::string &name) const {
   // Fetch if deferred
   DBTable *me = const_cast<DBTable *>(this); // grumble, grumble
   if (me->iatbl_deferred.present(name)) {
-    me->SetIArray(name, me->iatbl_deferred[name]->FetchIArray(GetS("_id"), name));
+    me->Set(name, me->iatbl_deferred[name]->FetchIArray(GetS("_id"), name));
     me->iatbl_deferred.erase(name);
   }
   
@@ -160,21 +155,51 @@ std::vector<double> DBTable::GetDArray(const std::string &name) const {
   // Fetch if deferred
   DBTable *me = const_cast<DBTable *>(this); // grumble, grumble
   if (me->datbl_deferred.present(name)) {
-    me->SetDArray(name, me->datbl_deferred[name]->FetchDArray(GetS("_id"), name));
+    me->Set(name, me->datbl_deferred[name]->FetchDArray(GetS("_id"), name));
     me->datbl_deferred.erase(name);
   }
     
-  if (!table.isMember(name))
+  if (!table.isMember(name)) {
     throw DBNotFoundError(tblname, index, name);
-  else if (GetFieldType(name) != DOUBLE_ARRAY)
+  } else if (GetFieldType(name) == INTEGER_ARRAY) {
+    const std::vector<int> iv = GetIArray(name);
+    std::vector<double> v(iv.size());
+    for (size_t i = 0; i < iv.size(); i++) {
+        v[i] = iv[i];
+    }
+    return v;
+  } else if (GetFieldType(name) != DOUBLE_ARRAY) {
     throw DBWrongTypeError(tblname, index, name, DOUBLE_ARRAY, GetFieldType(name));
-  else {
+  } else {
     const json::Value &json_array = table[name];
     return json_array.toVector<double>();
   }    
 }
 
+std::vector<std::string> DBTable::GetSArray(const std::string &name) const {
+    if (!table.isMember(name))
+        throw DBNotFoundError(tblname, index, name);
+    else if (GetFieldType(name) != STRING_ARRAY)
+        throw DBWrongTypeError(tblname, index, name, STRING_ARRAY, GetFieldType(name));
+    else
+        return table[name].toVector<std::string>();
+}
 
+std::vector<bool> DBTable::GetZArray(const std::string &name) const {
+    if (!table.isMember(name))
+        throw DBNotFoundError(tblname, index, name);
+    else if (GetFieldType(name) != BOOLEAN_ARRAY)
+        throw DBWrongTypeError(tblname, index, name, BOOLEAN_ARRAY, GetFieldType(name));
+    else
+        return table[name].toVector<bool>();
+}
+
+json::Value DBTable::GetJSON(const std::string &name) const {
+    if (!table.isMember(name))
+        throw DBNotFoundError(tblname, index, name);
+    else
+        return table[name];
+}
 
 
 } // namespace RAT

--- a/src/db/src/DBTextLoader.cc
+++ b/src/db/src/DBTextLoader.cc
@@ -360,11 +360,11 @@ DBTable *Parser::Next()
 	state = STATE_VAL;
 
 	switch (toktype) {
-	case Tokenizer::TYPE_STRING: tbl->SetS(identifier, tokenizer.Token());
+	case Tokenizer::TYPE_STRING: tbl->Set(identifier, tokenizer.Token());
 	  break;
-	case Tokenizer::TYPE_INTEGER: tbl->SetI(identifier, tokenizer.AsInt());
+	case Tokenizer::TYPE_INTEGER: tbl->Set(identifier, tokenizer.AsInt());
 	  break;
-	case Tokenizer::TYPE_DOUBLE: tbl->SetD(identifier, tokenizer.AsDouble());
+	case Tokenizer::TYPE_DOUBLE: tbl->Set(identifier, tokenizer.AsDouble());
 	  break;
 	default:
 	  assert(0); // should never get here
@@ -416,9 +416,9 @@ DBTable *Parser::Next()
 	// Allow array to be closed after a comma (to be nice)
 	state = STATE_VAL;
 	switch (array_type) {
-	case Tokenizer::TYPE_STRING: tbl->SetSArray(identifier, string_array); break;
-	case Tokenizer::TYPE_INTEGER: tbl->SetIArray(identifier, integer_array); break;
-	case Tokenizer::TYPE_DOUBLE: tbl->SetDArray(identifier, double_array); break;
+	case Tokenizer::TYPE_STRING: tbl->Set(identifier, string_array); break;
+	case Tokenizer::TYPE_INTEGER: tbl->Set(identifier, integer_array); break;
+	case Tokenizer::TYPE_DOUBLE: tbl->Set(identifier, double_array); break;
 	case Tokenizer::TYPE_ERROR:
 	  tokenizer.RaiseError("Empty arrays not allowed");
 	  break;
@@ -436,9 +436,9 @@ DBTable *Parser::Next()
 	  && tokenizer.Token() == "]") {
 	state = STATE_VAL;
 	switch (array_type) {
-	case Tokenizer::TYPE_STRING: tbl->SetSArray(identifier, string_array); break;
-	case Tokenizer::TYPE_INTEGER: tbl->SetIArray(identifier, integer_array); break;
-	case Tokenizer::TYPE_DOUBLE: tbl->SetDArray(identifier, double_array); break;
+	case Tokenizer::TYPE_STRING: tbl->Set(identifier, string_array); break;
+	case Tokenizer::TYPE_INTEGER: tbl->Set(identifier, integer_array); break;
+	case Tokenizer::TYPE_DOUBLE: tbl->Set(identifier, double_array); break;
 	case Tokenizer::TYPE_ERROR:
 	  tokenizer.RaiseError("Empty array not allowed");
 	  break;
@@ -570,13 +570,13 @@ std::vector<DBTable *> DBTextLoader::parse(std::string filename)
           run_range[0] = run_range[1] = 0;
 
           // Add modern run_range field
-          table->SetIArray("run_range", run_range);
+          table->Set("run_range", run_range);
           table->SetRunRange(run_range[0], run_range[1]);
         } else if (valid_begin[0] == -1 && valid_begin[1] == -1 && valid_end[0] == -1 && valid_end[1] == -1) {
           run_range[0] = run_range[1] = -1;
           
           // Add modern run_range field
-          table->SetIArray("run_range", run_range);
+          table->Set("run_range", run_range);
           table->SetRunRange(run_range[0], run_range[1]);          
         } else {
           cerr << "Table has old-style valid_begin/valid_end arrays not set to default or user plane.  Discarding..."

--- a/src/geo/src/TheiaDetectorFactory.cc
+++ b/src/geo/src/TheiaDetectorFactory.cc
@@ -193,28 +193,28 @@ void TheiaDetectorFactory::DefineDetector(DBLinkPtr /*detector*/) {
     vector<double> world_size(3);
     world_size[0] = world_size[1] = det_radius+10000.0;
     world_size[2] = det_halfheight+10000.0;
-    db->SetDArray("GEO","world","size",world_size);
-    db->SetD("GEO","tank","r_max",det_radius+tank_thickness);
-    db->SetD("GEO","tank","size_z",det_halfheight+tank_thickness);
-    db->SetD("GEO","detector","r_max",det_radius);
-    db->SetD("GEO","detector","size_z",det_halfheight);
+    db->Set("GEO","world","size",world_size);
+    db->Set("GEO","tank","r_max",det_radius+tank_thickness);
+    db->Set("GEO","tank","size_z",det_halfheight+tank_thickness);
+    db->Set("GEO","detector","r_max",det_radius);
+    db->Set("GEO","detector","size_z",det_halfheight);
 
     info << "Generating PMTINFO...\n";
-    db->SetDArray("PMTINFO","x",x);
-    db->SetDArray("PMTINFO","y",y);
-    db->SetDArray("PMTINFO","z",z);
-    db->SetDArray("PMTINFO","dir_x",dir_x);
-    db->SetDArray("PMTINFO","dir_y",dir_y);
-    db->SetDArray("PMTINFO","dir_z",dir_z);
-    db->SetIArray("PMTINFO","type",type);
+    db->Set("PMTINFO","x",x);
+    db->Set("PMTINFO","y",y);
+    db->Set("PMTINFO","z",z);
+    db->Set("PMTINFO","dir_x",dir_x);
+    db->Set("PMTINFO","dir_y",dir_y);
+    db->Set("PMTINFO","dir_z",dir_z);
+    db->Set("PMTINFO","type",type);
     
     info << "Update geometry fields related to veto PMTs...\n";
-    db->SetI("GEO","veto_pmts","start_idx",num_pmts);
-    db->SetI("GEO","veto_pmts","end_idx",total_pmts-1);
+    db->Set("GEO","veto_pmts","start_idx",num_pmts);
+    db->Set("GEO","veto_pmts","end_idx",total_pmts-1);
     
     info << "Update geometry fields related to normal PMTs...\n";
-    db->SetI("GEO","inner_pmts","start_idx",0);
-    db->SetI("GEO","inner_pmts","end_idx",num_pmts-1);
+    db->Set("GEO","inner_pmts","start_idx",0);
+    db->Set("GEO","inner_pmts","end_idx",num_pmts-1);
     
 }
 

--- a/src/geo/src/WatchmanDetectorFactory.cc
+++ b/src/geo/src/WatchmanDetectorFactory.cc
@@ -196,21 +196,21 @@ namespace RAT {
 
         info << "Update geometry fields related to the reflective and absorptive tarps...\n";
         // Side tarps
-        db->SetD("GEO","white_sheet_side","r_max",veto_radius);
-        db->SetD("GEO","white_sheet_side","r_min",veto_radius-10.0); // Marc Bergevin: Hardcoding in a 1 cm value for thickness
-        db->SetD("GEO","white_sheet_side","size_z",topbot_veto_offset);
+        db->Set("GEO","white_sheet_side","r_max",veto_radius);
+        db->Set("GEO","white_sheet_side","r_min",veto_radius-10.0); // Marc Bergevin: Hardcoding in a 1 cm value for thickness
+        db->Set("GEO","white_sheet_side","size_z",topbot_veto_offset);
 
-        db->SetD("GEO","black_sheet_side","r_max",pmt_radius+black_sheet_offset+black_sheet_thickness); //paige kunkle: expanding black tarp (+30cm) // Marc Bergevin: Hardcoding in a 1 cm value for thickness
-	db->SetD("GEO","black_sheet_side","r_min",pmt_radius+black_sheet_offset);  //paige kunkle: expanding black tarp (+30cm)
-	db->SetD("GEO","black_sheet_side","size_z",topbot_offset+black_sheet_offset);//paige kunkle: expanding black tarp (+30cm)
+        db->Set("GEO","black_sheet_side","r_max",pmt_radius+black_sheet_offset+black_sheet_thickness); //paige kunkle: expanding black tarp (+30cm) // Marc Bergevin: Hardcoding in a 1 cm value for thickness
+	db->Set("GEO","black_sheet_side","r_min",pmt_radius+black_sheet_offset);  //paige kunkle: expanding black tarp (+30cm)
+	db->Set("GEO","black_sheet_side","size_z",topbot_offset+black_sheet_offset);//paige kunkle: expanding black tarp (+30cm)
 
-        db->SetD("GEO","Rod_assemblies","r_max",(pmt_radius+300.)); // Based on Geofile thickness values of 10 cm
-        db->SetD("GEO","Rod_assemblies","r_min",(pmt_radius+200.));
-        db->SetD("GEO","Rod_assemblies","size_z",topbot_offset);
+        db->Set("GEO","Rod_assemblies","r_max",(pmt_radius+300.)); // Based on Geofile thickness values of 10 cm
+        db->Set("GEO","Rod_assemblies","r_min",(pmt_radius+200.));
+        db->Set("GEO","Rod_assemblies","size_z",topbot_offset);
 
-        db->SetD("GEO","white_sheet_tank_side","r_max",detector_size_d/2.0 -10.0);
-        db->SetD("GEO","white_sheet_tank_side","r_min",detector_size_d/2.0 -35.0);
-        db->SetD("GEO","white_sheet_tank_side","size_z",detector_size_z/2.0-35.0);
+        db->Set("GEO","white_sheet_tank_side","r_max",detector_size_d/2.0 -10.0);
+        db->Set("GEO","white_sheet_tank_side","r_min",detector_size_d/2.0 -35.0);
+        db->Set("GEO","white_sheet_tank_side","size_z",detector_size_z/2.0-35.0);
         
         
         //Top tarps
@@ -241,18 +241,18 @@ namespace RAT {
         
         
         
-        db->SetD("GEO","white_sheet_top","r_max",veto_radius);
-        db->SetDArray("GEO","white_sheet_top","position",move_white_top);
-        db->SetD("GEO","black_sheet_top","r_max",pmt_radius+black_sheet_offset);//paige kunkle: expanding black tarp (+30cm)
-        db->SetDArray("GEO","black_sheet_top","position",move_black_top);
-        db->SetD("GEO","Top_cap_framework","r_max",pmt_radius);
-        db->SetDArray("GEO","Top_cap_framework","position",move_topcap);
-        db->SetD("GEO","Wall_support_truss_top","r_min",pmt_radius+5.0);  // Bergevin: Values based
-        db->SetD("GEO","Wall_support_truss_top","r_max",pmt_radius+200.0);// on geofile
-        db->SetDArray("GEO","Wall_support_truss_top","position",move_toptruss);
+        db->Set("GEO","white_sheet_top","r_max",veto_radius);
+        db->Set("GEO","white_sheet_top","position",move_white_top);
+        db->Set("GEO","black_sheet_top","r_max",pmt_radius+black_sheet_offset);//paige kunkle: expanding black tarp (+30cm)
+        db->Set("GEO","black_sheet_top","position",move_black_top);
+        db->Set("GEO","Top_cap_framework","r_max",pmt_radius);
+        db->Set("GEO","Top_cap_framework","position",move_topcap);
+        db->Set("GEO","Wall_support_truss_top","r_min",pmt_radius+5.0);  // Bergevin: Values based
+        db->Set("GEO","Wall_support_truss_top","r_max",pmt_radius+200.0);// on geofile
+        db->Set("GEO","Wall_support_truss_top","position",move_toptruss);
     
-        db->SetD("GEO","white_sheet_tank_top","r_max",detector_size_d/2.0 -35.0);
-        db->SetDArray("GEO","white_sheet_tank_top","position",move_toptanktarp);
+        db->Set("GEO","white_sheet_tank_top","r_max",detector_size_d/2.0 -35.0);
+        db->Set("GEO","white_sheet_tank_top","position",move_toptanktarp);
         
         
         
@@ -282,18 +282,18 @@ namespace RAT {
         
         
         
-        db->SetD("GEO","white_sheet_bottom","r_max",veto_radius);
-        db->SetDArray("GEO","white_sheet_bottom","position",move_white_bottom);
-        db->SetD("GEO","black_sheet_bottom","r_max",pmt_radius+black_sheet_offset);//paige kunkle: expanding black tarp (+30cm)
-        db->SetDArray("GEO","black_sheet_bottom","position",move_black_bottom);
-        db->SetD("GEO","Bottom_cap_framework","r_max",pmt_radius);
-        db->SetDArray("GEO","Bottom_cap_framework","position",move_bottomcap);
-        db->SetD("GEO","Wall_support_truss_bottom","r_min",pmt_radius+5.0);  // Bergevin: Values based
-        db->SetD("GEO","Wall_support_truss_bottom","r_max",pmt_radius+200.0);// on geofile
-        db->SetDArray("GEO","Wall_support_truss_bottom","position",move_bottomtruss);
+        db->Set("GEO","white_sheet_bottom","r_max",veto_radius);
+        db->Set("GEO","white_sheet_bottom","position",move_white_bottom);
+        db->Set("GEO","black_sheet_bottom","r_max",pmt_radius+black_sheet_offset);//paige kunkle: expanding black tarp (+30cm)
+        db->Set("GEO","black_sheet_bottom","position",move_black_bottom);
+        db->Set("GEO","Bottom_cap_framework","r_max",pmt_radius);
+        db->Set("GEO","Bottom_cap_framework","position",move_bottomcap);
+        db->Set("GEO","Wall_support_truss_bottom","r_min",pmt_radius+5.0);  // Bergevin: Values based
+        db->Set("GEO","Wall_support_truss_bottom","r_max",pmt_radius+200.0);// on geofile
+        db->Set("GEO","Wall_support_truss_bottom","position",move_bottomtruss);
     
-        db->SetD("GEO","white_sheet_tank_bottom","r_max",detector_size_d/2.0 -35.0);
-        db->SetDArray("GEO","white_sheet_tank_bottom","position",move_bottomtanktarp);
+        db->Set("GEO","white_sheet_tank_bottom","r_max",detector_size_d/2.0 -35.0);
+        db->Set("GEO","white_sheet_tank_bottom","position",move_bottomtanktarp);
         
         
         info << "Adjusting the Bottom cap standoff frames ...\n";
@@ -346,51 +346,51 @@ namespace RAT {
             info << "New size " << standoff_frame_4_size[0] << " " << standoff_frame_4_size[1] << " " << standoff_frame_4_size[2] << "...\n";
         }
  
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_0","size",standoff_frame_0_size);
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_0","position",standoff_frame_0_pos);
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_1","size",standoff_frame_1_size);
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_1","position",standoff_frame_1_pos);
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_2","size",standoff_frame_2_size);
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_2","position",standoff_frame_2_pos);
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_3","size",standoff_frame_3_size);
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_3","position",standoff_frame_3_pos);
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_4","size",standoff_frame_4_size);
-        db->SetDArray("GEO","Bottom_cap_standoff_frame_4","position",standoff_frame_4_pos);
+        db->Set("GEO","Bottom_cap_standoff_frame_0","size",standoff_frame_0_size);
+        db->Set("GEO","Bottom_cap_standoff_frame_0","position",standoff_frame_0_pos);
+        db->Set("GEO","Bottom_cap_standoff_frame_1","size",standoff_frame_1_size);
+        db->Set("GEO","Bottom_cap_standoff_frame_1","position",standoff_frame_1_pos);
+        db->Set("GEO","Bottom_cap_standoff_frame_2","size",standoff_frame_2_size);
+        db->Set("GEO","Bottom_cap_standoff_frame_2","position",standoff_frame_2_pos);
+        db->Set("GEO","Bottom_cap_standoff_frame_3","size",standoff_frame_3_size);
+        db->Set("GEO","Bottom_cap_standoff_frame_3","position",standoff_frame_3_pos);
+        db->Set("GEO","Bottom_cap_standoff_frame_4","size",standoff_frame_4_size);
+        db->Set("GEO","Bottom_cap_standoff_frame_4","position",standoff_frame_4_pos);
 
         
         info << "Override default PMTINFO information...\n";
-        db->SetDArray("PMTINFO","x",x);
-        db->SetDArray("PMTINFO","y",y);
-        db->SetDArray("PMTINFO","z",z);
-        db->SetDArray("PMTINFO","dir_x",dir_x);
-        db->SetDArray("PMTINFO","dir_y",dir_y);
-        db->SetDArray("PMTINFO","dir_z",dir_z);
-        db->SetIArray("PMTINFO","type",type);
+        db->Set("PMTINFO","x",x);
+        db->Set("PMTINFO","y",y);
+        db->Set("PMTINFO","z",z);
+        db->Set("PMTINFO","dir_x",dir_x);
+        db->Set("PMTINFO","dir_y",dir_y);
+        db->Set("PMTINFO","dir_z",dir_z);
+        db->Set("PMTINFO","type",type);
 
         info << "Update geometry fields related to the reflective and absorptive tarps...\n";
         
         
         info << "Update geometry fields related to veto PMTs...\n";
-        db->SetI("GEO","shield","veto_start",num_pmts);
-        db->SetI("GEO","shield","veto_len",num_vetos);
-        db->SetI("GEO","veto_pmts","start_idx",num_pmts);
-        db->SetI("GEO","veto_pmts","end_idx",total_pmts-1);
+        db->Set("GEO","shield","veto_start",num_pmts);
+        db->Set("GEO","shield","veto_len",num_vetos);
+        db->Set("GEO","veto_pmts","start_idx",num_pmts);
+        db->Set("GEO","veto_pmts","end_idx",total_pmts-1);
 
         info << "Update geometry fields related to normal PMTs...\n";
-        db->SetI("GEO","shield","cols",cols);
-        db->SetI("GEO","shield","rows",rows);
-        db->SetI("GEO","shield","inner_start",0);
-        db->SetI("GEO","shield","inner_len",num_pmts);
-        db->SetI("GEO","inner_pmts","start_idx",0);
-        db->SetI("GEO","inner_pmts","end_idx",num_pmts-1);
+        db->Set("GEO","shield","cols",cols);
+        db->Set("GEO","shield","rows",rows);
+        db->Set("GEO","shield","inner_start",0);
+        db->Set("GEO","shield","inner_len",num_pmts);
+        db->Set("GEO","inner_pmts","start_idx",0);
+        db->Set("GEO","inner_pmts","end_idx",num_pmts-1);
 
         info << "Update cable positions to match shield...\n";
-        db->SetDArray("cable_pos","x",cable_x);
-        db->SetDArray("cable_pos","y",cable_y);
-        db->SetDArray("cable_pos","z",vector<double>(cols,0.0));
-        db->SetDArray("cable_pos","dir_x",vector<double>(cols,0.0));
-        db->SetDArray("cable_pos","dir_y",vector<double>(cols,0.0));
-        db->SetDArray("cable_pos","dir_z",vector<double>(cols,1.0));
+        db->Set("cable_pos","x",cable_x);
+        db->Set("cable_pos","y",cable_y);
+        db->Set("cable_pos","z",vector<double>(cols,0.0));
+        db->Set("cable_pos","dir_x",vector<double>(cols,0.0));
+        db->Set("cable_pos","dir_y",vector<double>(cols,0.0));
+        db->Set("cable_pos","dir_z",vector<double>(cols,1.0));
 
         //DBLinkPtr inner_pmts = db->GetLink("GEO","inner_pmts");
         //  const vector<double> &size = table->GetDArray("boxsize");
@@ -412,14 +412,14 @@ namespace RAT {
         minshift.push_back(-_shift);
         info << "Update height of rock and cavern air... (" << _shift << " mm shift)\n";
 
-        db->SetDArray("GEO","rock_1",  "position",shift);
-        // db->SetDArray("GEO","cavern",  "position",noshift);
+        db->Set("GEO","rock_1",  "position",shift);
+        // db->Set("GEO","cavern",  "position",noshift);
         
         info << "Adjust size and position of tank...\n";
-        db->SetD("GEO","tank","r_max",detector_size_d/2.0);
-        db->SetD("GEO","tank","size_z",detector_size_z/2.0);
-        db->SetDArray("GEO","tank","position",minshift);
-        // db->SetDArray("GEO","detector","position",minshift);
+        db->Set("GEO","tank","r_max",detector_size_d/2.0);
+        db->Set("GEO","tank","size_z",detector_size_z/2.0);
+        db->Set("GEO","tank","position",minshift);
+        // db->Set("GEO","detector","position",minshift);
     }
 
 }

--- a/src/geo/src/WatchmanWLSPSquareDetectorFactory.cc
+++ b/src/geo/src/WatchmanWLSPSquareDetectorFactory.cc
@@ -239,20 +239,20 @@ namespace RAT {
         
           info << "Update geometry fields related to the reflective and absorptive tarps...\n";
           // Side tarps
-          db->SetD("GEO","white_sheet_side","r_max",veto_radius+60.0);
-          db->SetD("GEO","white_sheet_side","r_min",veto_radius-10.0+60.0); // Marc Bergevin: Hardcoding in a 1 cm value for tickness
-          db->SetD("GEO","white_sheet_side","size_z",topbot_veto_offset);
-          db->SetD("GEO","black_sheet_side","r_max",pmt_radius+10.0+60.0);
-          db->SetD("GEO","black_sheet_side","r_min",pmt_radius+60.0); // Marc Bergevin: Hardcoding in a 1 cm value for tickness
-          db->SetD("GEO","black_sheet_side","size_z",topbot_offset);
+          db->Set("GEO","white_sheet_side","r_max",veto_radius+60.0);
+          db->Set("GEO","white_sheet_side","r_min",veto_radius-10.0+60.0); // Marc Bergevin: Hardcoding in a 1 cm value for tickness
+          db->Set("GEO","white_sheet_side","size_z",topbot_veto_offset);
+          db->Set("GEO","black_sheet_side","r_max",pmt_radius+10.0+60.0);
+          db->Set("GEO","black_sheet_side","r_min",pmt_radius+60.0); // Marc Bergevin: Hardcoding in a 1 cm value for tickness
+          db->Set("GEO","black_sheet_side","size_z",topbot_offset);
           
-          db->SetD("GEO","Rod_assemblies","r_max",(pmt_radius+300.)); // Based on Geofile thickness values of 10 cm
-          db->SetD("GEO","Rod_assemblies","r_min",(pmt_radius+200.));
-          db->SetD("GEO","Rod_assemblies","size_z",topbot_offset);
+          db->Set("GEO","Rod_assemblies","r_max",(pmt_radius+300.)); // Based on Geofile thickness values of 10 cm
+          db->Set("GEO","Rod_assemblies","r_min",(pmt_radius+200.));
+          db->Set("GEO","Rod_assemblies","size_z",topbot_offset);
 
-          db->SetD("GEO","white_sheet_tank_side","r_max",detector_size_d/2.0 -10.0+60.0);
-          db->SetD("GEO","white_sheet_tank_side","r_min",detector_size_d/2.0 -35.0+60.0);
-          db->SetD("GEO","white_sheet_tank_side","size_z",detector_size_z/2.0-35.0+60.0);
+          db->Set("GEO","white_sheet_tank_side","r_max",detector_size_d/2.0 -10.0+60.0);
+          db->Set("GEO","white_sheet_tank_side","r_min",detector_size_d/2.0 -35.0+60.0);
+          db->Set("GEO","white_sheet_tank_side","size_z",detector_size_z/2.0-35.0+60.0);
         
         
           //Top tarps
@@ -283,18 +283,18 @@ namespace RAT {
         
         
         
-          db->SetD("GEO","white_sheet_top","r_max",veto_radius);
-          db->SetDArray("GEO","white_sheet_top","position",move_white_top);
-          db->SetD("GEO","black_sheet_top","r_max",pmt_radius);
-          db->SetDArray("GEO","black_sheet_top","position",move_black_top);
-          db->SetD("GEO","Top_cap_framework","r_max",pmt_radius);
-          db->SetDArray("GEO","Top_cap_framework","position",move_topcap);
-          db->SetD("GEO","Wall_support_truss_top","r_min",pmt_radius+5.0);  // Bergevin: Values based
-          db->SetD("GEO","Wall_support_truss_top","r_max",pmt_radius+200.0);// on geofile
-          db->SetDArray("GEO","Wall_support_truss_top","position",move_toptruss);
+          db->Set("GEO","white_sheet_top","r_max",veto_radius);
+          db->Set("GEO","white_sheet_top","position",move_white_top);
+          db->Set("GEO","black_sheet_top","r_max",pmt_radius);
+          db->Set("GEO","black_sheet_top","position",move_black_top);
+          db->Set("GEO","Top_cap_framework","r_max",pmt_radius);
+          db->Set("GEO","Top_cap_framework","position",move_topcap);
+          db->Set("GEO","Wall_support_truss_top","r_min",pmt_radius+5.0);  // Bergevin: Values based
+          db->Set("GEO","Wall_support_truss_top","r_max",pmt_radius+200.0);// on geofile
+          db->Set("GEO","Wall_support_truss_top","position",move_toptruss);
     
-          db->SetD("GEO","white_sheet_tank_top","r_max",detector_size_d/2.0 -35.0);
-          db->SetDArray("GEO","white_sheet_tank_top","position",move_toptanktarp);
+          db->Set("GEO","white_sheet_tank_top","r_max",detector_size_d/2.0 -35.0);
+          db->Set("GEO","white_sheet_tank_top","position",move_toptanktarp);
         
         
         
@@ -324,18 +324,18 @@ namespace RAT {
         
         
         
-          db->SetD("GEO","white_sheet_bottom","r_max",veto_radius);
-          db->SetDArray("GEO","white_sheet_bottom","position",move_white_bottom);
-          db->SetD("GEO","black_sheet_bottom","r_max",pmt_radius);
-          db->SetDArray("GEO","black_sheet_bottom","position",move_black_bottom);
-          db->SetD("GEO","Bottom_cap_framework","r_max",pmt_radius);
-          db->SetDArray("GEO","Bottom_cap_framework","position",move_bottomcap);
-          db->SetD("GEO","Wall_support_truss_bottom","r_min",pmt_radius+5.0);  // Bergevin: Values based
-          db->SetD("GEO","Wall_support_truss_bottom","r_max",pmt_radius+200.0);// on geofile
-          db->SetDArray("GEO","Wall_support_truss_bottom","position",move_bottomtruss);
+          db->Set("GEO","white_sheet_bottom","r_max",veto_radius);
+          db->Set("GEO","white_sheet_bottom","position",move_white_bottom);
+          db->Set("GEO","black_sheet_bottom","r_max",pmt_radius);
+          db->Set("GEO","black_sheet_bottom","position",move_black_bottom);
+          db->Set("GEO","Bottom_cap_framework","r_max",pmt_radius);
+          db->Set("GEO","Bottom_cap_framework","position",move_bottomcap);
+          db->Set("GEO","Wall_support_truss_bottom","r_min",pmt_radius+5.0);  // Bergevin: Values based
+          db->Set("GEO","Wall_support_truss_bottom","r_max",pmt_radius+200.0);// on geofile
+          db->Set("GEO","Wall_support_truss_bottom","position",move_bottomtruss);
     
-          db->SetD("GEO","white_sheet_tank_bottom","r_max",detector_size_d/2.0 -35.0);
-          db->SetDArray("GEO","white_sheet_tank_bottom","position",move_bottomtanktarp);
+          db->Set("GEO","white_sheet_tank_bottom","r_max",detector_size_d/2.0 -35.0);
+          db->Set("GEO","white_sheet_tank_bottom","position",move_bottomtanktarp);
         
         
           info << "Adjusting the Bottom cap standoff frames ...\n";
@@ -388,82 +388,93 @@ namespace RAT {
               info << "New size " << standoff_frame_4_size[0] << " " << standoff_frame_4_size[1] << " " << standoff_frame_4_size[2] << "...\n";
           }
  
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_0","size",standoff_frame_0_size);
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_0","position",standoff_frame_0_pos);
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_1","size",standoff_frame_1_size);
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_1","position",standoff_frame_1_pos);
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_2","size",standoff_frame_2_size);
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_2","position",standoff_frame_2_pos);
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_3","size",standoff_frame_3_size);
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_3","position",standoff_frame_3_pos);
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_4","size",standoff_frame_4_size);
-          db->SetDArray("GEO","Bottom_cap_standoff_frame_4","position",standoff_frame_4_pos);
+          db->Set("GEO","Bottom_cap_standoff_frame_0","size",standoff_frame_0_size);
+          db->Set("GEO","Bottom_cap_standoff_frame_0","position",standoff_frame_0_pos);
+          db->Set("GEO","Bottom_cap_standoff_frame_1","size",standoff_frame_1_size);
+          db->Set("GEO","Bottom_cap_standoff_frame_1","position",standoff_frame_1_pos);
+          db->Set("GEO","Bottom_cap_standoff_frame_2","size",standoff_frame_2_size);
+          db->Set("GEO","Bottom_cap_standoff_frame_2","position",standoff_frame_2_pos);
+          db->Set("GEO","Bottom_cap_standoff_frame_3","size",standoff_frame_3_size);
+          db->Set("GEO","Bottom_cap_standoff_frame_3","position",standoff_frame_3_pos);
+          db->Set("GEO","Bottom_cap_standoff_frame_4","size",standoff_frame_4_size);
+          db->Set("GEO","Bottom_cap_standoff_frame_4","position",standoff_frame_4_pos);
           info << "Override default PMTINFO information...\n";
-          db->SetDArray("PMTINFO","x",x);
-          db->SetDArray("PMTINFO","y",y);
-          db->SetDArray("PMTINFO","z",z);
-          db->SetDArray("PMTINFO","dir_x",dir_x);
-          db->SetDArray("PMTINFO","dir_y",dir_y);
-          db->SetDArray("PMTINFO","dir_z",dir_z);
-          db->SetIArray("PMTINFO","type",type);
+          db->Set("PMTINFO","x",x);
+          db->Set("PMTINFO","y",y);
+          db->Set("PMTINFO","z",z);
+          db->Set("PMTINFO","dir_x",dir_x);
+          db->Set("PMTINFO","dir_y",dir_y);
+          db->Set("PMTINFO","dir_z",dir_z);
+          db->Set("PMTINFO","type",type);
         }
         
         info << "Override default WLSPINFO information...\n";
 
-        db->SetDArray("WLSPINFO","x",xp);
-        db->SetDArray("WLSPINFO","y",yp);
-        db->SetDArray("WLSPINFO","z",zp);
-        db->SetDArray("WLSPINFO","dir_x",dir_x);
-        db->SetDArray("WLSPINFO","dir_y",dir_y);
-        db->SetDArray("WLSPINFO","dir_z",dir_z);
-        db->SetIArray("WLSPINFO","type",type);
+        db->Set("WLSPINFO","x",xp);
+        db->Set("WLSPINFO","y",yp);
+        db->Set("WLSPINFO","z",zp);
+        db->Set("WLSPINFO","dir_x",dir_x);
+        db->Set("WLSPINFO","dir_y",dir_y);
+        db->Set("WLSPINFO","dir_z",dir_z);
+        db->Set("WLSPINFO","type",type);
         
         if (photocathode_coverage != 0.00) {
           info << "Update geometry fields related to the reflective and absorptive tarps...\n";
         
         
           info << "Update geometry fields related to veto PMTs...\n";
-          db->SetI("GEO","shield","veto_start",num_pmts);
-          db->SetI("GEO","shield","veto_len",num_vetos);
-          db->SetI("GEO","veto_pmts","start_idx",num_pmts);
-          db->SetI("GEO","veto_pmts","end_idx",total_pmts-1);
+          db->Set("GEO","shield","veto_start",num_pmts);
+          db->Set("GEO","shield","veto_len",num_vetos);
+          db->Set("GEO","veto_pmts","start_idx",num_pmts);
+          db->Set("GEO","veto_pmts","end_idx",total_pmts-1);
 
           info << "Update geometry fields related to normal PMTs...\n";
-          db->SetI("GEO","shield","cols",cols);
-          db->SetI("GEO","shield","rows",rows);
-          db->SetI("GEO","shield","inner_start",0);
-          db->SetI("GEO","shield","inner_len",num_pmts);
-          db->SetI("GEO","inner_pmts","start_idx",0);
-          db->SetI("GEO","inner_pmts","end_idx",num_pmts-1);
+          db->Set("GEO","shield","cols",cols);
+          db->Set("GEO","shield","rows",rows);
+          db->Set("GEO","shield","inner_start",0);
+          db->Set("GEO","shield","inner_len",num_pmts);
+          db->Set("GEO","inner_pmts","start_idx",0);
+          db->Set("GEO","inner_pmts","end_idx",num_pmts-1);
 
           info << "Update cable positions to match shield...\n";
-          db->SetDArray("cable_pos","x",cable_x);
-          db->SetDArray("cable_pos","y",cable_y);
-          db->SetDArray("cable_pos","z",vector<double>(cols,0.0));
-          db->SetDArray("cable_pos","dir_x",vector<double>(cols,0.0));
-          db->SetDArray("cable_pos","dir_y",vector<double>(cols,0.0));
-          db->SetDArray("cable_pos","dir_z",vector<double>(cols,1.0));
+          db->Set("cable_pos","x",cable_x);
+          db->Set("cable_pos","y",cable_y);
+          db->Set("cable_pos","z",vector<double>(cols,0.0));
+          db->Set("cable_pos","dir_x",vector<double>(cols,0.0));
+          db->Set("cable_pos","dir_y",vector<double>(cols,0.0));
+          db->Set("cable_pos","dir_z",vector<double>(cols,1.0));
 
           //This generates the geometry values for the WLS plates and their reflectors
-          db->SetDArray("GEO","WLS_Plates","size",{(pmt_space/2.0)-10.0,(pmt_space/2.0)-10.0,wlsp->GetDArray("z")[1]});
-          db->SetDArray("GEO","WLS_Plates","r_max",{rho_edge[1]+5.0,rho_edge[1]-15.0});
-          db->SetDArray("GEO","WLS_Plates","r_min",{0.0,0.0});
-          db->SetDArray("GEO","WLS_Plates","z",{-wlsp->GetDArray("z")[1]-1.0,wlsp->GetDArray("z")[1]+1.0});
-          db->SetDArray("GEO","WLSP_reflector","inner_size",{(pmt_space/2.0)-10.0,(pmt_space/2.0)-10.0,wlsp->GetDArray("z")[1]+2.0});
-          db->SetDArray("GEO","WLSP_reflector","outer_size",{(pmt_space/2.0)-10.0+2.0,(pmt_space/2.0)-10.0+2.0,wlsp->GetDArray("z")[1]});
+          db->Set("GEO","WLS_Plates","size",
+              vector<double>({(pmt_space/2.0)-10.0,(pmt_space/2.0)-10.0,wlsp->GetDArray("z")[1]}) );
+          db->Set("GEO","WLS_Plates","r_max",
+              vector<double>({rho_edge[1]+5.0,rho_edge[1]-15.0}));
+          db->Set("GEO","WLS_Plates","r_min",vector<double>({0.0,0.0}));
+          db->Set("GEO","WLS_Plates","z",
+              vector<double>({-wlsp->GetDArray("z")[1]-1.0,wlsp->GetDArray("z")[1]+1.0}));
+          db->Set("GEO","WLSP_reflector","inner_size",
+              vector<double>({(pmt_space/2.0)-10.0,(pmt_space/2.0)-10.0,wlsp->GetDArray("z")[1]+2.0}));
+          db->Set("GEO","WLSP_reflector","outer_size",
+              vector<double>({(pmt_space/2.0)-10.0+2.0,(pmt_space/2.0)-10.0+2.0,wlsp->GetDArray("z")[1]}));
         }
         else {
           //If the baseline detector configuration is used, more constant values are used.  I still do this here rather than in the geo file because it reads in the PMT dimensions
-          db->SetDArray("GEO","WLS_Plates","size",{240.0,240.0,wlsp->GetDArray("z")[1]});
-          db->SetDArray("GEO","WLS_Plates","r_max",{rho_edge[1]+5.0,rho_edge[1]-15.0});
-          db->SetDArray("GEO","WLS_Plates","r_min",{0.0,0.0});
-          db->SetDArray("GEO","WLS_Plates","z",{-wlsp->GetDArray("z")[1]-1.0,wlsp->GetDArray("z")[1]+1.0});
-          db->SetDArray("GEO","WLSP_reflector","inner_size",{240.0,240.0,wlsp->GetDArray("z")[1]+2.0});
-          db->SetDArray("GEO","WLSP_reflector","outer_size",{242.0,242.0,wlsp->GetDArray("z")[1]});
+          db->Set("GEO","WLS_Plates","size",
+              vector<double>({240.0,240.0,wlsp->GetDArray("z")[1]}));
+          db->Set("GEO","WLS_Plates","r_max",
+              vector<double>({rho_edge[1]+5.0,rho_edge[1]-15.0}));
+          db->Set("GEO","WLS_Plates","r_min",
+              vector<double>({0.0,0.0}));
+          db->Set("GEO","WLS_Plates","z",
+              vector<double>({-wlsp->GetDArray("z")[1]-1.0,wlsp->GetDArray("z")[1]+1.0}));
+          db->Set("GEO","WLSP_reflector","inner_size",
+              vector<double>({240.0,240.0,wlsp->GetDArray("z")[1]+2.0}));
+          db->Set("GEO","WLSP_reflector","outer_size",
+              vector<double>({242.0,242.0,wlsp->GetDArray("z")[1]}));
         }
         
-        //db->SetDArray("GEO","WLSP_reflector","inner_size",{(pmt_space/2.0)-8.0,(pmt_space/2.0)-8.0,wlspcover->GetDArray("z")[1]});
-        //db->SetDArray("GEO","WLSP_reflector","outer_size",{(pmt_space/2.0)-9.0,(pmt_space/2.0)-9.0,wlspcover->GetDArray("z")[1]+1});
+        //db->Set("GEO","WLSP_reflector","inner_size",{(pmt_space/2.0)-8.0,(pmt_space/2.0)-8.0,wlspcover->GetDArray("z")[1]});
+        //db->Set("GEO","WLSP_reflector","outer_size",{(pmt_space/2.0)-9.0,(pmt_space/2.0)-9.0,wlspcover->GetDArray("z")[1]+1});
         
         
 
@@ -488,14 +499,14 @@ namespace RAT {
           minshift.push_back(-_shift);
           info << "Update height of rock and cavern air... (" << _shift << " mm shift)\n";
   
-          db->SetDArray("GEO","rock_1",  "position",shift);
-          // db->SetDArray("GEO","cavern",  "position",noshift);
+          db->Set("GEO","rock_1",  "position",shift);
+          // db->Set("GEO","cavern",  "position",noshift);
         
           info << "Adjust size and position of tank...\n";
-          db->SetD("GEO","tank","r_max",detector_size_d/2.0);
-          db->SetD("GEO","tank","size_z",detector_size_z/2.0);
-          db->SetDArray("GEO","tank","position",minshift);
-          // db->SetDArray("GEO","detector","position",minshift);
+          db->Set("GEO","tank","r_max",detector_size_d/2.0);
+          db->Set("GEO","tank","size_z",detector_size_z/2.0);
+          db->Set("GEO","tank","position",minshift);
+          // db->Set("GEO","detector","position",minshift);
         }
         
     }

--- a/tools/rat/rat.cc
+++ b/tools/rat/rat.cc
@@ -102,11 +102,11 @@ int main(int argc, char **argv) {
   try { // Catch database errors
     // Set default input and output files
     if (options.input_filename != "") {
-      rdb->SetS("IO", "", "default_input_filename", options.input_filename);
+      rdb->Set("IO", "", "default_input_filename", options.input_filename);
       info << "Setting default input file to " << options.input_filename << "\n";
     }
     if (options.output_filename != "") {
-      rdb->SetS("IO", "", "default_output_filename", options.output_filename);
+      rdb->Set("IO", "", "default_output_filename", options.output_filename);
       info << "Setting default output file to " << options.output_filename << "\n";
     }
 


### PR DESCRIPTION
From Ben Land (part of the PMT improvements PR in public ratpac)
See github.com/rat-pac pull request #37 for details

Database arguments have been templated and allow the passing of array
arguments. This is critical when dealing with changing databse states,
a prime example being arrays of PMT property tables (since individual
PMTs have different gain/threshold/etc.)