### PR TITLE
Discriminator Threshold

### DIFF
--- a/data/DAQ.ratdb
+++ b/data/DAQ.ratdb
@@ -19,5 +19,6 @@ trigger_resolution: 1.0,
 lookback: 400.0,
 max_hit_time: 1000000.0,
 pmt_type: 1,
-trigger_on_noise: 1
+trigger_on_noise: 1,
+discriminator: 0.25
 }

--- a/mac/watchman_dev.mac
+++ b/mac/watchman_dev.mac
@@ -28,9 +28,10 @@
 /rat/procset trigger_resolution 1.0
 /rat/procset max_hit_time 1000000.0
 /rat/procset pulse_width 100.0
+/rat/procset discriminator 0.25
 
 /rat/proc count
-/rat/procset update 10
+/rat/procset update 1000
 
 # Use IO.default_output_filename
 /rat/proclast outroot

--- a/src/daq/include/RAT/SplitEVDAQProc.hh
+++ b/src/daq/include/RAT/SplitEVDAQProc.hh
@@ -25,6 +25,7 @@ protected:
   double fTriggerResolution;
   double fLookback;
   double fMaxHitTime;
+  double fDiscriminator;
   int fPmtType;
   int fTriggerOnNoise;
   std::vector<double> fSPECharge;

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -163,6 +163,10 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
           }
         }
       }
+      // If the integrated charge in the trigger window is below discriminator
+      // threshold do not record the event.
+      if ( integratedCharge < fDiscriminator )
+        pmtInEvent = false;
       std::sort(hitTimes.begin(), hitTimes.end());
       if( pmtInEvent )
       {

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -24,6 +24,7 @@ SplitEVDAQProc::SplitEVDAQProc() : Processor("splitevdaq") {
   fTriggerResolution = ldaq->GetD("trigger_resolution");
   fLookback          = ldaq->GetD("lookback");
   fMaxHitTime        = ldaq->GetD("max_hit_time");
+  fDiscriminator     = ldaq->GetD("discriminator");
   fPmtType           = ldaq->GetI("pmt_type");
   fTriggerOnNoise    = ldaq->GetI("trigger_on_noise");
 }
@@ -35,6 +36,13 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
   // Not included yet
   // - Noise on the trigger pulse height, rise-time, etc
   // - Disciminator on charge (all hits assumed to trigger)
+  // Note on the discriminator mk-I. Right now each photon is presumed to
+  // deposit its charge instantaneously and independently, which is faster
+  // for simulations but is less accurate for events with multi-pe since
+  // we aren't summing the hits to create a PMT waveform. We should add this
+  // feature as an option to test the accuracy of this simplified model, noting
+  // that the feature will likely cause a slowdown when used because of its
+  // increased complexity.
 
   DS::MC *mc = ds->GetMC();
   // Prune the previous EV branchs if one exists
@@ -53,7 +61,10 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
       // Do we want to trigger on noise hits?
       if( !fTriggerOnNoise && photon->IsDarkHit() ) continue;
       double time = photon->GetFrontEndTime();
+      double charge = photon->GetCharge();
       if (time > fMaxHitTime) continue;
+      // Pass discriminator threshold?
+      if (charge < fDiscriminator) continue;
       if (time > (lastTrigger + fPmtLockout))
       {
         trigPulses.push_back(time);
@@ -188,6 +199,8 @@ void SplitEVDAQProc::SetD(std::string param, double value)
     fLookback = value;
   else if( param == "max_hit_time" )
     fMaxHitTime = value;
+  else if( param == "discriminator" )
+    fDiscriminator = value;
   else
     throw ParamUnknown(param);
 }


### PR DESCRIPTION
Simple discriminator threshold added to the DAQ that checks on a
photon-by-photon basis to see if the deposited charge is high enough to
allow the PMT to contribute to the global trigger. This does not look at
the total waveform, and thus does not correctly work with photon pileup
(they are treated as statistical instead of correlated).