### PR TITLE
Adding more macro parameters to noiseproc

### DIFF
--- a/mac/watchman_dev.mac
+++ b/mac/watchman_dev.mac
@@ -17,6 +17,9 @@
 ## Include noise (Before DAQ!)
 /rat/proc noise
 /rat/procset rate 3000.0
+/rat/procset lookback 1000.0
+/rat/procset lookforward 1000.0
+/rat/procset maxtime 1000000.0
 /rat/procset nearhits 1
 ## Use the SplitEVDAQ
 /rat/proc splitevdaq

--- a/src/daq/src/NoiseProc.cc
+++ b/src/daq/src/NoiseProc.cc
@@ -215,6 +215,12 @@ void NoiseProc::SetD(std::string param, double value)
       fNoiseRate = value;
     else
       throw ParamInvalid(param, "Noise rate must be positive");
+  else if(param == "lookback")
+    fLookback = abs(value);
+  else if(param == "lookforward")
+    fLookforward = abs(value);
+  else if(param == "maxtime")
+    fMaxTime = abs(value);
   else
     throw ParamUnknown(param);
 }


### PR DESCRIPTION
A few commands to control the noise processor from a macro without /rat/db/set. These are also safe to negative signs.

```
/rat/procset lookback 1000.0
/rat/procset lookforward 1000.0
/rat/procset maxtime 1000000.0
```