### PR TITLE
Fixes positron angular distribution in IBDgen

### DIFF
--- a/src/gen/include/RAT/IBDgen.hh
+++ b/src/gen/include/RAT/IBDgen.hh
@@ -36,7 +36,14 @@ public:
 
   // Differential cross section for inverse beta decay
   static double CrossSection(double Enu, double CosThetaLab);
+  // dE/dCosT for inverse beta decay (E = first order positron energy)
+  static double dE1dCosT(double Enu, double CosThetaLab);
+  // Maximum of dE/dCosT
+  static double EvalMax(double Enu, double FluxMax);
   
+  // Positron energy (first order)
+  static double PositronEnergy(double Enu, double CosThetaLab); 
+
   // Flux as a function of energy.  Interpolated from table in IBD RATDB table
   double Flux(float E) const { return rmpflux(E); };
 


### PR DESCRIPTION
Addresses issue #162 where angular (cos theta) distribution of IBD positrons was uniform.

CosTheta used to calculate first order correction to positron energy.
Neutron kinematics calculated from positron energy and momentum resulted
in neutron kinetic energy = nan in some cases, especially for low-energy
incident neutrinos. Seen in log files:

    -------- EEEE ------- G4Exception-START -------- EEEE -------
    *** G4Exception : ProcMan201
      issued by : G4VProcess::SubtractNumberOfInteractionLengthLeft()
    Negative currentInteractionLength for Decay 
    *** Event Must Be Aborted ***
    G4Track (0x4ecd22e0) - track ID = 2, parent ID = 0
    Particle type : neutron - creator process : not available
    Kinetic energy : nan eV  - Momentum direction : (0,0,1)
    Step length : 8.27338 m   - total energy deposit : 0 eV
    Pre-step point : (3291.78,1291.14,8850) - Physical volume : detector_target_fv (wbls_gd_01pct_ly100_WM_0121)
    - defined by : Transportation - step status : 1
    Post-step point : (3291.78,1291.14,8850) - Physical volume : detector_target_fv (wbls_gd_01pct_ly100_WM_0121)
    - defined by : Transportation - step status : 7
    *** Note: Step information might not be properly updated.


Distribution should now be weighted by Flux * dSigma/dE * dE/dCosT.

IBD spectra looking better e.g. Sizewell B reactor spectrum:

![sizewell_before_fix](https://user-images.githubusercontent.com/22293593/146395055-4235509f-2975-4ff2-93af-7ead8995b1a7.png)

![sizewell_post_fix](https://user-images.githubusercontent.com/22293593/146395313-d1969c50-a3fe-46fb-9947-e57fadc462e9.png)

